### PR TITLE
Remove reflections dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,10 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.reflections</groupId>-->
+            <!--<artifactId>reflections</artifactId>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>typetools</artifactId>

--- a/src/main/java/io/katharsis/dispatcher/registry/ControllerRegistryBuilder.java
+++ b/src/main/java/io/katharsis/dispatcher/registry/ControllerRegistryBuilder.java
@@ -5,9 +5,10 @@ import io.katharsis.dispatcher.controller.BaseController;
 import io.katharsis.dispatcher.controller.resource.ResourceIncludeField;
 import io.katharsis.dispatcher.controller.resource.ResourceUpsert;
 import io.katharsis.resource.include.IncludeLookupSetter;
+import io.katharsis.resource.registry.ClassLookup;
+import io.katharsis.resource.registry.ClassLookupDefault;
 import io.katharsis.resource.registry.ResourceRegistry;
 import io.katharsis.utils.parser.TypeParser;
-import org.reflections.Reflections;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -44,7 +45,7 @@ public class ControllerRegistryBuilder {
     public ControllerRegistry build() throws Exception {
 
 
-        Reflections reflections = new Reflections("io.katharsis.dispatcher.controller");
+        ClassLookup reflections = new ClassLookupDefault("io.katharsis.dispatcher.controller");
 
         Set<Class<? extends BaseController>> controllerClasses =
                 reflections.getSubTypesOf(BaseController.class);

--- a/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryBuilder.java
+++ b/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryBuilder.java
@@ -1,7 +1,8 @@
 package io.katharsis.errorhandling.mapper;
 
 import io.katharsis.resource.exception.init.InvalidResourceException;
-import org.reflections.Reflections;
+import io.katharsis.resource.registry.ClassLookup;
+import io.katharsis.resource.registry.ClassLookupDefault;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -27,12 +28,12 @@ public final class ExceptionMapperRegistryBuilder {
     }
 
     private void scanForCustomMappers(String resourceSearchPackage) throws InstantiationException, IllegalAccessException {
-        Reflections reflections;
+        ClassLookup reflections;
         if (resourceSearchPackage != null) {
             String[] packageNames = resourceSearchPackage.split(",");
-            reflections = new Reflections(packageNames);
+            reflections = new ClassLookupDefault(packageNames);
         } else {
-            reflections = new Reflections(resourceSearchPackage);
+            reflections = new ClassLookupDefault(resourceSearchPackage);
         }
         Set<Class<?>> exceptionMapperClasses = reflections.getTypesAnnotatedWith(ExceptionMapperProvider.class);
 

--- a/src/main/java/io/katharsis/resource/registry/AnnotatedRepositoryEntryBuilder.java
+++ b/src/main/java/io/katharsis/resource/registry/AnnotatedRepositoryEntryBuilder.java
@@ -8,7 +8,6 @@ import io.katharsis.resource.registry.repository.AnnotatedRelationshipEntryBuild
 import io.katharsis.resource.registry.repository.AnnotatedResourceEntryBuilder;
 import io.katharsis.resource.registry.repository.RelationshipEntry;
 import io.katharsis.resource.registry.repository.ResourceEntry;
-import org.reflections.Reflections;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
@@ -27,7 +26,7 @@ public class AnnotatedRepositoryEntryBuilder implements RepositoryEntryBuilder {
     }
 
     @Override
-    public ResourceEntry<?, ?> buildResourceRepository(Reflections reflections, Class<?> resourceClass) {
+    public ResourceEntry<?, ?> buildResourceRepository(ClassLookup reflections, Class<?> resourceClass) {
         Predicate<Class<?>> classPredicate =
             clazz -> resourceClass.equals(clazz.getAnnotation(JsonApiResourceRepository.class).value());
 
@@ -40,7 +39,7 @@ public class AnnotatedRepositoryEntryBuilder implements RepositoryEntryBuilder {
     }
 
     @Override
-    public List<RelationshipEntry<?, ?>> buildRelationshipRepositories(Reflections reflections, Class<?> resourceClass) {
+    public List<RelationshipEntry<?, ?>> buildRelationshipRepositories(ClassLookup reflections, Class<?> resourceClass) {
         Predicate<Class<?>> classPredicate =
             clazz -> resourceClass.equals(clazz.getAnnotation(JsonApiRelationshipRepository.class).source());
 
@@ -50,7 +49,7 @@ public class AnnotatedRepositoryEntryBuilder implements RepositoryEntryBuilder {
             .collect(Collectors.toList());
     }
 
-    private List<Object> findRepositoryObject(Reflections reflections, Predicate<Class<?>> classPredicate, Class<? extends Annotation> annotation) {
+    private List<Object> findRepositoryObject(ClassLookup reflections, Predicate<Class<?>> classPredicate, Class<? extends Annotation> annotation) {
         return reflections.getTypesAnnotatedWith(annotation).stream()
             .filter(classPredicate)
             .map(clazz -> {

--- a/src/main/java/io/katharsis/resource/registry/ClassLookup.java
+++ b/src/main/java/io/katharsis/resource/registry/ClassLookup.java
@@ -1,0 +1,17 @@
+package io.katharsis.resource.registry;
+
+import io.katharsis.errorhandling.mapper.ExceptionMapperProvider;
+import io.katharsis.repository.ResourceRepository;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Created by staaleu on 5/11/15.
+ */
+public interface ClassLookup {
+    Set<Class<?>> getTypesAnnotatedWith(Class<? extends Annotation> annotation);
+
+    <X> Set<Class<? extends X>> getSubTypesOf(Class<X> resourceRepositoryClass);
+}

--- a/src/main/java/io/katharsis/resource/registry/ClassLookupDefault.java
+++ b/src/main/java/io/katharsis/resource/registry/ClassLookupDefault.java
@@ -1,0 +1,104 @@
+package io.katharsis.resource.registry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * Created by staaleu on 5/11/15.
+ */
+public class ClassLookupDefault implements ClassLookup {
+
+    private static final Logger log = LoggerFactory.getLogger(ClassLookupDefault.class);
+
+    private final String[] searchPackages;
+    private final List<? extends Class<?>> clazzes;
+
+    public ClassLookupDefault(final String ... searchPackages) {
+        this.searchPackages = searchPackages;
+        final URLClassLoader urlClassLoader =
+                (URLClassLoader) Thread.currentThread().getContextClassLoader();
+        clazzes = Stream.of(urlClassLoader.getURLs())
+                .flatMap(this::uriToEntries)
+                .filter(this::includeEntry)
+                .flatMap(name -> {
+                    try {
+                        return Stream.of(Class.forName(name.replace('/', '.').replace(".class", "")));
+                    } catch (ClassNotFoundException e) {
+                        log.warn("Failed to load class for entry {}", name, e);
+                        return Stream.empty();
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<Class<?>> getTypesAnnotatedWith(final Class<? extends Annotation> annotation) {
+        return getClassStream()
+                .filter(clazz -> clazz.isAnnotationPresent(annotation))
+                .collect(Collectors.toSet());
+    }
+
+    private Stream<? extends Class<?>> getClassStream() {
+        return clazzes.stream();
+    }
+
+    private final Stream<String> uriToEntries(final URL url) {
+        try {
+            final File file = new File(url.toURI());
+            if (file.isDirectory()) {
+                final Path p = file.toPath();
+                return Files.walk(p).map(path -> {
+                    final String relativePath = p.relativize(path).toString();
+                    return relativePath;
+                });
+            } else {
+                return new ZipFile(file).stream().map(ZipEntry::getName);
+            }
+        } catch (URISyntaxException | IOException e) {
+            log.warn("Failed to open classpath entry {}", url, e);
+            return Stream.empty();
+        }
+    }
+
+    private boolean includeEntry(final String name) {
+        if (!name.endsWith(".class")) {
+            return false;
+        }
+        if (searchPackages == null || searchPackages.length == 0) {
+            return true;
+        } else {
+            for (String searchPackage : searchPackages) {
+                if (name.startsWith(searchPackage.replace('.', '/'))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public <X> Set<Class<? extends X>> getSubTypesOf(final Class<X> resourceRepositoryClass) {
+        return getClassStream()
+                .filter(clazz -> resourceRepositoryClass.isAssignableFrom(clazz))
+                .map(clazz -> (Class<? extends X>) clazz)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/io/katharsis/resource/registry/DirectRepositoryEntryBuilder.java
+++ b/src/main/java/io/katharsis/resource/registry/DirectRepositoryEntryBuilder.java
@@ -9,7 +9,6 @@ import io.katharsis.resource.registry.repository.DirectResourceEntry;
 import io.katharsis.resource.registry.repository.RelationshipEntry;
 import io.katharsis.resource.registry.repository.ResourceEntry;
 import net.jodah.typetools.TypeResolver;
-import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +27,7 @@ public class DirectRepositoryEntryBuilder implements RepositoryEntryBuilder {
     }
 
     @Override
-    public ResourceEntry<?, ?> buildResourceRepository(Reflections reflections, Class<?> resourceClass) {
+    public ResourceEntry<?, ?> buildResourceRepository(ClassLookup reflections, Class<?> resourceClass) {
         Optional<Class<? extends ResourceRepository>> repoClass = reflections.getSubTypesOf(ResourceRepository.class)
             .stream()
             .filter(clazz -> {
@@ -47,7 +46,7 @@ public class DirectRepositoryEntryBuilder implements RepositoryEntryBuilder {
     }
 
     @Override
-    public List<RelationshipEntry<?, ?>> buildRelationshipRepositories(Reflections reflections, Class<?> resourceClass) {
+    public List<RelationshipEntry<?, ?>> buildRelationshipRepositories(ClassLookup reflections, Class<?> resourceClass) {
         Set<Class<? extends RelationshipRepository>> relationshipRepositoryClasses = reflections
             .getSubTypesOf(RelationshipRepository.class);
 

--- a/src/main/java/io/katharsis/resource/registry/RepositoryEntryBuilder.java
+++ b/src/main/java/io/katharsis/resource/registry/RepositoryEntryBuilder.java
@@ -2,7 +2,6 @@ package io.katharsis.resource.registry;
 
 import io.katharsis.resource.registry.repository.RelationshipEntry;
 import io.katharsis.resource.registry.repository.ResourceEntry;
-import org.reflections.Reflections;
 
 import java.util.List;
 
@@ -12,7 +11,7 @@ import java.util.List;
  */
 public interface RepositoryEntryBuilder {
 
-    ResourceEntry<?, ?> buildResourceRepository(Reflections reflections, Class<?> resourceClass);
+    ResourceEntry<?, ?> buildResourceRepository(ClassLookup reflections, Class<?> resourceClass);
 
-    List<RelationshipEntry<?, ?>> buildRelationshipRepositories(Reflections reflections, Class<?> resourceClass);
+    List<RelationshipEntry<?, ?>> buildRelationshipRepositories(ClassLookup reflections, Class<?> resourceClass);
 }

--- a/src/main/java/io/katharsis/resource/registry/RepositoryEntryBuilderFacade.java
+++ b/src/main/java/io/katharsis/resource/registry/RepositoryEntryBuilderFacade.java
@@ -5,7 +5,6 @@ import io.katharsis.repository.NotFoundRepository;
 import io.katharsis.resource.registry.repository.DirectResourceEntry;
 import io.katharsis.resource.registry.repository.RelationshipEntry;
 import io.katharsis.resource.registry.repository.ResourceEntry;
-import org.reflections.Reflections;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -25,7 +24,7 @@ public class RepositoryEntryBuilderFacade implements RepositoryEntryBuilder {
     }
 
     @Override
-    public ResourceEntry<?, ?> buildResourceRepository(Reflections reflections, Class<?> resourceClass) {
+    public ResourceEntry<?, ?> buildResourceRepository(ClassLookup reflections, Class<?> resourceClass) {
         ResourceEntry<?, ?> resourceEntry = annotatedRepositoryEntryBuilder
             .buildResourceRepository(reflections, resourceClass);
         if (resourceEntry == null) {
@@ -39,7 +38,7 @@ public class RepositoryEntryBuilderFacade implements RepositoryEntryBuilder {
     }
 
     @Override
-    public List<RelationshipEntry<?, ?>> buildRelationshipRepositories(Reflections reflections, Class<?> resourceClass) {
+    public List<RelationshipEntry<?, ?>> buildRelationshipRepositories(ClassLookup reflections, Class<?> resourceClass) {
         List<RelationshipEntry<?, ?>> annotationEntries = annotatedRepositoryEntryBuilder
             .buildRelationshipRepositories(reflections, resourceClass);
         List<RelationshipEntry<?, ?>> targetEntries = new LinkedList<>(annotationEntries);

--- a/src/main/java/io/katharsis/resource/registry/ResourceRegistryBuilder.java
+++ b/src/main/java/io/katharsis/resource/registry/ResourceRegistryBuilder.java
@@ -6,7 +6,6 @@ import io.katharsis.resource.information.ResourceInformation;
 import io.katharsis.resource.information.ResourceInformationBuilder;
 import io.katharsis.resource.registry.repository.RelationshipEntry;
 import io.katharsis.resource.registry.repository.ResourceEntry;
-import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,14 +39,13 @@ public class ResourceRegistryBuilder {
      * @return an instance of ResourceRegistry
      */
     public ResourceRegistry build(String packageName, @SuppressWarnings("SameParameterValue") String serviceUrl) {
-        Reflections reflections;
+        ClassLookup reflections;
         if (packageName != null) {
             String[] packageNames = packageName.split(",");
-            reflections = new Reflections(packageNames);
+            reflections = new ClassLookupDefault(packageNames);
         } else {
-            reflections = new Reflections(packageName);
+            reflections = new ClassLookupDefault();
         }
-
 
         Set<Class<?>> jsonApiResources = reflections.getTypesAnnotatedWith(JsonApiResource.class);
         Set<ResourceInformation> resourceInformationSet = jsonApiResources.stream()


### PR DESCRIPTION
This can probably do with some cleanup, I just hacked this together quickly. All tests still pass.

I am not a big fan of dependencies, and pulling in Reflections, seems to drag along a few other dependencies as well. This rewrite replaces Reflections with a small class that does only what Katharsis needs.

I am not using katharsis currently, but I am looking at it as a backend for my Ember frontend, which is why I did this change. If there are comments, I will see if I can find some time to clean this up further.