### PR TITLE
ensure resource registry uses proper class during lookup

### DIFF
--- a/src/main/java/io/katharsis/jackson/serializer/ContainerSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/ContainerSerializer.java
@@ -85,7 +85,7 @@ public class ContainerSerializer extends JsonSerializer<Container> {
      * <a href="http://jsonapi.org/format/#document-structure-resource-types"></a>.
      */
     private void writeData(JsonGenerator gen, Object data, Set<String> includedFields) throws IOException {
-        Class<?> dataClass = ClassUtils.getJsonApiResourceClass(data);
+        Class<?> dataClass = data.getClass();
         String resourceType = resourceRegistry.getResourceType(dataClass);
 
         gen.writeStringField(TYPE_FIELD_NAME, resourceType);

--- a/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
+++ b/src/main/java/io/katharsis/resource/registry/ResourceRegistry.java
@@ -2,6 +2,7 @@ package io.katharsis.resource.registry;
 
 import io.katharsis.resource.annotations.JsonApiResource;
 import io.katharsis.resource.exception.init.ResourceNotFoundInitializationException;
+import io.katharsis.utils.ClassUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,8 @@ public class ResourceRegistry {
     }
 
     public RegistryEntry getEntry(Class clazz) {
-        RegistryEntry registryEntry = resources.get(clazz);
+        Class resourceClazz = ClassUtils.getJsonApiResourceClass(clazz);
+        RegistryEntry registryEntry = resources.get(resourceClazz);
         if (registryEntry != null) {
             return registryEntry;
         }
@@ -44,7 +46,8 @@ public class ResourceRegistry {
     }
 
     public String getResourceType(Class clazz) {
-        Annotation[] annotations = clazz.getAnnotations();
+        Class resourceClazz = ClassUtils.getJsonApiResourceClass(clazz);
+        Annotation[] annotations = resourceClazz.getAnnotations();
         for (Annotation annotation : annotations) {
             if (annotation instanceof JsonApiResource) {
                 JsonApiResource apiResource = (JsonApiResource) annotation;

--- a/src/main/java/io/katharsis/utils/ClassUtils.java
+++ b/src/main/java/io/katharsis/utils/ClassUtils.java
@@ -141,7 +141,7 @@ public class ClassUtils {
     }
 
     /**
-     * Returns the first clazz in the ancestory hierarchy with the JsonApiResource annotation
+     * Returns the first clazz in the ancestor hierarchy with the JsonApiResource annotation
      * @param data instance
      * @param <T> instance type
      * @return class or null


### PR DESCRIPTION
This PR is a follow up on #133 and tries to solve the issue #132 at the root, namly inside the resource registry.

We are experiencing the following error:
```
! io.katharsis.resource.exception.init.ResourceNotFoundInitializationException: Resource of class not found: com.sample.Entity_$$_jvst95a_2a
! at io.katharsis.resource.registry.ResourceRegistry.getEntry(ResourceRegistry.java:43) ~[katharsis-core-2.0.1.jar:na]
! at io.katharsis.jackson.serializer.IncludedRelationshipExtractor.getRelationshipFields(IncludedRelationshipExtractor.java:165) ~[katharsis-core-2.0.1.jar:na]
! at io.katharsis.jackson.serializer.IncludedRelationshipExtractor.getIncludedByDefaultResources(IncludedRelationshipExtractor.java:62) ~[katharsis-core-2.0.1.jar:na]
! at io.katharsis.jackson.serializer.IncludedRelationshipExtractor.getIncludedByDefaultResources(IncludedRelationshipExtractor.java:85) ~[katharsis-core-2.0.1.jar:na]
! at io.katharsis.jackson.serializer.IncludedRelationshipExtractor.extractDefaultIncludedFields(IncludedRelationshipExtractor.java:48) ~[katharsis-core-2.0.1.jar:na]
! at io.katharsis.jackson.serializer.IncludedRelationshipExtractor.extractIncludedResources(IncludedRelationshipExtractor.java:36) ~[katharsis-core-2.0.1.jar:na]
! at io.katharsis.jackson.serializer.BaseResponseSerializer.serializeSingle(BaseResponseSerializer.java:89) ~[katharsis-core-2.0.1.jar:na]
! at io.katharsis.jackson.serializer.BaseResponseSerializer.writeResponseWithResources(BaseResponseSerializer.java:69) ~[katharsis-core-2.0.1.jar:na]
! at io.katharsis.jackson.serializer.BaseResponseSerializer.serialize(BaseResponseSerializer.java:37) ~[katharsis-core-2.0.1.jar:na]
! at io.katharsis.jackson.serializer.BaseResponseSerializer.serialize(BaseResponseSerializer.java:15) ~[katharsis-core-2.0.1.jar:na]
! at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:130) ~[jackson-databind-2.6.3.jar:2.6.3]
