### PR TITLE
squid:S2325 "private" methods that don't access instance data should be "static"

### DIFF
--- a/src/main/java/io/katharsis/jackson/serializer/ErrorResponseSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/ErrorResponseSerializer.java
@@ -84,7 +84,7 @@ public class ErrorResponseSerializer extends JsonSerializer<ErrorResponse> {
         }
     }
 
-    private void writeStringIfExists(String fieldName, String value, JsonGenerator gen) throws IOException {
+    private static void writeStringIfExists(String fieldName, String value, JsonGenerator gen) throws IOException {
         if (value != null) {
             gen.writeStringField(fieldName, value);
         }

--- a/src/main/java/io/katharsis/queryParams/DefaultQueryParamsParser.java
+++ b/src/main/java/io/katharsis/queryParams/DefaultQueryParamsParser.java
@@ -68,7 +68,7 @@ public class DefaultQueryParamsParser implements QueryParamsParser {
      * @param queryKey    Filtering key
      * @return Filtered query params
      */
-    private Map<String, Set<String>> filterQueryParamsByKey(Map<String, Set<String>> queryParams, String queryKey) {
+    private static Map<String, Set<String>> filterQueryParamsByKey(Map<String, Set<String>> queryParams, String queryKey) {
         Map<String, Set<String>> filteredQueryParams = new HashMap<>();
 
         for (Map.Entry<String, Set<String>> entry : queryParams.entrySet()) {

--- a/src/main/java/io/katharsis/repository/ParametersFactory.java
+++ b/src/main/java/io/katharsis/repository/ParametersFactory.java
@@ -71,7 +71,7 @@ public class ParametersFactory {
     /**
      * Source: https://stackoverflow.com/a/80503
      */
-    private Object[] concatenate(Object[] a, Object[] b) {
+    private static Object[] concatenate(Object[] a, Object[] b) {
 
         int aLen = a.length;
         int bLen = b.length;

--- a/src/main/java/io/katharsis/request/path/PathBuilder.java
+++ b/src/main/java/io/katharsis/request/path/PathBuilder.java
@@ -107,7 +107,7 @@ public class PathBuilder {
         return new PathIds(pathIds);
     }
 
-    private String[] splitPath(String path) {
+    private static String[] splitPath(String path) {
         if (path.startsWith(SEPARATOR)) {
             path = path.substring(1);
         }

--- a/src/main/java/io/katharsis/resource/field/ResourceFieldNameTransformer.java
+++ b/src/main/java/io/katharsis/resource/field/ResourceFieldNameTransformer.java
@@ -79,7 +79,7 @@ public class ResourceFieldNameTransformer {
         return name;
     }
 
-    private AnnotationMap buildAnnotationMap(Annotation[] declaredAnnotations) {
+    private static AnnotationMap buildAnnotationMap(Annotation[] declaredAnnotations) {
         AnnotationMap annotationMap = new AnnotationMap();
         for (Annotation annotation : declaredAnnotations) {
             annotationMap.add(annotation);
@@ -103,7 +103,7 @@ public class ResourceFieldNameTransformer {
         return name;
     }
 
-    private String extractMethodName(Method method, int nameStart) {
+    private static String extractMethodName(Method method, int nameStart) {
         String resourceName = method.getName().substring(nameStart);
         return resourceName.substring(0, 1).toLowerCase() + resourceName.substring(1);
     }

--- a/src/main/java/io/katharsis/utils/ClassUtils.java
+++ b/src/main/java/io/katharsis/utils/ClassUtils.java
@@ -220,7 +220,7 @@ public class ClassUtils {
         return !void.class.equals(method.getReturnType());
     }
 
-    private boolean isSetter(Method method) {
+    private static boolean isSetter(Method method) {
         if (!method.getName().startsWith("set"))
             return false;
         if (method.getName().length() < 4)

--- a/src/main/java/io/katharsis/utils/parser/TypeParser.java
+++ b/src/main/java/io/katharsis/utils/parser/TypeParser.java
@@ -82,7 +82,7 @@ public class TypeParser {
         return parsedValue;
     }
 
-    private <T extends Serializable> boolean isEnum(Class<T> clazz) {
+    private static <T extends Serializable> boolean isEnum(Class<T> clazz) {
         return clazz.isEnum();
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2325 "private" methods that don't access instance data should be "static".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava