### PR TITLE
quid:S00115 Constant names should comply with a naming convention

### DIFF
--- a/src/main/java/io/katharsis/queryParams/DefaultQueryParamsParser.java
+++ b/src/main/java/io/katharsis/queryParams/DefaultQueryParamsParser.java
@@ -27,37 +27,37 @@ public class DefaultQueryParamsParser implements QueryParamsParser {
 
     @Override
     public Map<String, Set<String>> parseFiltersParameters(final Map<String, Set<String>> queryParams) {
-        String filterKey = RestrictedQueryParamsMembers.filter.name();
+        String filterKey = RestrictedQueryParamsMembers.FILTER.name();
         return filterQueryParamsByKey(queryParams, filterKey);
     }
 
     @Override
     public Map<String, Set<String>> parseSortingParameters(final Map<String, Set<String>> queryParams) {
-        String sortingKey = RestrictedQueryParamsMembers.sort.name();
+        String sortingKey = RestrictedQueryParamsMembers.SORT.name();
         return filterQueryParamsByKey(queryParams, sortingKey);
     }
 
     @Override
     public Map<String, Set<String>> parseGroupingParameters(final Map<String, Set<String>> queryParams) {
-        String groupingKey = RestrictedQueryParamsMembers.group.name();
+        String groupingKey = RestrictedQueryParamsMembers.GROUP.name();
         return filterQueryParamsByKey(queryParams, groupingKey);
     }
 
     @Override
     public Map<String, Set<String>> parseIncludedFieldsParameters(final Map<String, Set<String>> queryParams) {
-        String sparseKey = RestrictedQueryParamsMembers.fields.name();
+        String sparseKey = RestrictedQueryParamsMembers.FIELDS.name();
         return filterQueryParamsByKey(queryParams, sparseKey);
     }
 
     @Override
     public Map<String, Set<String>> parseIncludedRelationsParameters(final Map<String, Set<String>> queryParams) {
-        String includeKey = RestrictedQueryParamsMembers.include.name();
+        String includeKey = RestrictedQueryParamsMembers.INCLUDE.name();
         return filterQueryParamsByKey(queryParams, includeKey);
     }
 
     @Override
     public Map<String, Set<String>> parsePaginationParameters(final Map<String, Set<String>> queryParams) {
-        String pagingKey = RestrictedQueryParamsMembers.page.name();
+        String pagingKey = RestrictedQueryParamsMembers.PAGE.name();
         return filterQueryParamsByKey(queryParams, pagingKey);
     }
 

--- a/src/main/java/io/katharsis/queryParams/QueryParams.java
+++ b/src/main/java/io/katharsis/queryParams/QueryParams.java
@@ -49,7 +49,7 @@ public class QueryParams {
 
         for (Map.Entry<String, Set<String>> entry : filters.entrySet()) {
 
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.filter.name());
+            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.FILTER.name());
 
             String resourceType = propertyList.get(0);
             String propertyPath = StringUtils.join(".", propertyList.subList(1, propertyList.size()));
@@ -99,7 +99,7 @@ public class QueryParams {
 
         for (Map.Entry<String, Set<String>> entry : sorting.entrySet()) {
 
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.sort.name());
+            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.SORT.name());
 
             String resourceType = propertyList.get(0);
             String propertyPath = StringUtils.join(".", propertyList.subList(1, propertyList.size()));
@@ -156,7 +156,7 @@ public class QueryParams {
 
         for (Map.Entry<String, Set<String>> entry : grouping.entrySet()) {
 
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.group.name());
+            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.GROUP.name());
 
             if (propertyList.size() > 1) {
                 throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'group' parameter " +
@@ -210,7 +210,7 @@ public class QueryParams {
         Map<RestrictedPaginationKeys, Integer> decodedPagination = new LinkedHashMap<>();
 
         for (Map.Entry<String, Set<String>> entry : pagination.entrySet()) {
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.page.name());
+            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.PAGE.name());
 
             if (propertyList.size() > 1) {
                 throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'page' parameter " +
@@ -253,7 +253,7 @@ public class QueryParams {
         Map<String, Set<String>> temporarySparseMap = new LinkedHashMap<>();
 
         for (Map.Entry<String, Set<String>> entry : sparse.entrySet()) {
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.fields.name());
+            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.FIELDS.name());
 
             if (propertyList.size() > 1) {
                 throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'fields' " +
@@ -308,7 +308,7 @@ public class QueryParams {
         Map<String, Set<Inclusion>> temporaryInclusionsMap = new LinkedHashMap<>();
 
         for (Map.Entry<String, Set<String>> entry : inclusions.entrySet()) {
-            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.include.name());
+            List<String> propertyList = buildPropertyListFromEntry(entry, RestrictedQueryParamsMembers.INCLUDE.name());
 
             if (propertyList.size() > 1) {
                 throw new ParametersDeserializationException("Exceeded maximum level of nesting of 'include' " +

--- a/src/main/java/io/katharsis/queryParams/RestrictedPaginationKeys.java
+++ b/src/main/java/io/katharsis/queryParams/RestrictedPaginationKeys.java
@@ -1,6 +1,6 @@
 package io.katharsis.queryParams;
 
 public enum RestrictedPaginationKeys {
-    offset,
-    limit
+    OFFSET,
+    LIMIT
 }

--- a/src/main/java/io/katharsis/queryParams/RestrictedSortingValues.java
+++ b/src/main/java/io/katharsis/queryParams/RestrictedSortingValues.java
@@ -7,9 +7,9 @@ public enum RestrictedSortingValues {
     /**
      * Ascending order
      */
-    asc,
+    ASC,
     /**
      * Descending
      */
-    desc
+	DESC
 }

--- a/src/main/java/io/katharsis/resource/RestrictedQueryParamsMembers.java
+++ b/src/main/java/io/katharsis/resource/RestrictedQueryParamsMembers.java
@@ -4,25 +4,25 @@ public enum RestrictedQueryParamsMembers {
     /**
      * Set of collection's fields used for filtering
      */
-    filter,
+    FILTER,
     /**
      * Set of collection's fields used for sorting
      */
-    sort,
+    SORT,
     /**
      * Field to group by the collection
      */
-    group,
+    GROUP,
     /**
      * Pagination properties
      */
-    page,
+    PAGE,
     /**
      * List of specified fields to include in models
      */
-    fields,
+    FIELDS,
     /**
      * Additional resources that should be attached to response
      */
-    include
+    INCLUDE
 }

--- a/src/main/java/io/katharsis/resource/RestrictedResourceNames.java
+++ b/src/main/java/io/katharsis/resource/RestrictedResourceNames.java
@@ -8,6 +8,6 @@ public enum RestrictedResourceNames {
      * It is an url relationship indicator
      * See <a href="http://jsonapi.org/format/#fetching-relationships">Fetching Relationships</a>
      */
-    links,
+    LINKS,
 
 }

--- a/src/test/java/io/katharsis/dispatcher/controller/collection/CollectionGetTest.java
+++ b/src/test/java/io/katharsis/dispatcher/controller/collection/CollectionGetTest.java
@@ -179,7 +179,7 @@ public class CollectionGetTest extends BaseControllerTest {
         JsonPath jsonPath = pathBuilder.buildPath("/tasks/" + taskId );
         ResourceGet responseGetResp = new ResourceGet(resourceRegistry, typeParser, includeFieldSetter);
         Map<String, Set<String>> queryParams = new HashMap<>();
-        queryParams.put(RestrictedQueryParamsMembers.include.name() + "[tasks]",
+        queryParams.put(RestrictedQueryParamsMembers.INCLUDE.name() + "[tasks]",
             Collections.singleton("includedProjects"));
         QueryParams queryParams1 = new QueryParamsBuilder(new DefaultQueryParamsParser()).buildQueryParams(queryParams);
 
@@ -261,7 +261,7 @@ public class CollectionGetTest extends BaseControllerTest {
         JsonPath jsonPath = pathBuilder.buildPath("/tasks/" + taskId );
         ResourceGet responseGetResp = new ResourceGet(resourceRegistry, typeParser, includeFieldSetter);
         Map<String, Set<String>> queryParams = new HashMap<>();
-        queryParams.put(RestrictedQueryParamsMembers.include.name() + "[tasks]",
+        queryParams.put(RestrictedQueryParamsMembers.INCLUDE.name() + "[tasks]",
             Collections.singleton("[\"projects\"]"));
         QueryParams requestParams = new QueryParamsBuilder(new DefaultQueryParamsParser()).buildQueryParams(queryParams);
 

--- a/src/test/java/io/katharsis/dispatcher/controller/resource/ResourceGetTest.java
+++ b/src/test/java/io/katharsis/dispatcher/controller/resource/ResourceGetTest.java
@@ -174,7 +174,7 @@ public class ResourceGetTest extends BaseControllerTest {
         JsonPath jsonPath = pathBuilder.buildPath("/tasks/" + taskId );
         ResourceGet responseGetResp = new ResourceGet(resourceRegistry, typeParser, includeFieldSetter);
         Map<String, Set<String>> queryParams = new HashMap<>();
-        queryParams.put(RestrictedQueryParamsMembers.include.name() + "[tasks]",
+        queryParams.put(RestrictedQueryParamsMembers.INCLUDE.name() + "[tasks]",
             Collections.singleton("includedProject"));
         QueryParams queryParamsObject = new QueryParamsBuilder(new DefaultQueryParamsParser()).buildQueryParams(queryParams);
 
@@ -255,7 +255,7 @@ public class ResourceGetTest extends BaseControllerTest {
         JsonPath jsonPath = pathBuilder.buildPath("/tasks/" + taskId );
         ResourceGet responseGetResp = new ResourceGet(resourceRegistry, typeParser, includeFieldSetter);
         Map<String, Set<String>> queryParams = new HashMap<>();
-        queryParams.put(RestrictedQueryParamsMembers.include.name() + "[tasks]",
+        queryParams.put(RestrictedQueryParamsMembers.INCLUDE.name() + "[tasks]",
             Collections.singleton("[\"project\"]"));
         QueryParams requestParams = new QueryParamsBuilder(new DefaultQueryParamsParser()).buildQueryParams(queryParams);
 

--- a/src/test/java/io/katharsis/jackson/ContainerSerializerTest.java
+++ b/src/test/java/io/katharsis/jackson/ContainerSerializerTest.java
@@ -64,7 +64,7 @@ public class ContainerSerializerTest extends BaseSerializerTest {
 
         QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder(new DefaultQueryParamsParser());
         QueryParams queryParams = queryParamsBuilder.buildQueryParams(
-            Collections.singletonMap("fields[projects]", Collections.singleton("name")));
+            Collections.singletonMap("FIELDS[projects]", Collections.singleton("name")));
         JsonPath jsonPath = new PathBuilder(resourceRegistry).buildPath("/projects");
 
         // WHEN
@@ -87,7 +87,7 @@ public class ContainerSerializerTest extends BaseSerializerTest {
 
         QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder(new DefaultQueryParamsParser());
         QueryParams queryParams = queryParamsBuilder.buildQueryParams(
-            Collections.singletonMap("fields[tasks]", Collections.singleton("project")));
+            Collections.singletonMap("FIELDS[tasks]", Collections.singleton("project")));
         JsonPath jsonPath = new PathBuilder(resourceRegistry).buildPath("/tasks");
 
         // WHEN
@@ -110,7 +110,7 @@ public class ContainerSerializerTest extends BaseSerializerTest {
 
         QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder(new DefaultQueryParamsParser());
         QueryParams queryParams = queryParamsBuilder.buildQueryParams(
-            Collections.singletonMap("fields[projects]", Collections.singleton("name")));
+            Collections.singletonMap("FIELDS[projects]", Collections.singleton("name")));
         JsonPath jsonPath = new PathBuilder(resourceRegistry).buildPath("/tasks");
 
         // WHEN

--- a/src/test/java/io/katharsis/jackson/IncludedRelationshipExtractorTest.java
+++ b/src/test/java/io/katharsis/jackson/IncludedRelationshipExtractorTest.java
@@ -123,7 +123,7 @@ public class IncludedRelationshipExtractorTest {
     @Test
     public void onInclusionWithDefaultInclusionShouldReturnOneElement() throws Exception {
         // GIVEN
-        QueryParams queryParams = getRequestParamsWithInclusion("include[classAsWithInclusion]",
+        QueryParams queryParams = getRequestParamsWithInclusion("INCLUDE[classAsWithInclusion]",
             "classBsWithInclusion");
 
         ResourceResponse response = new ResourceResponse(null, new ResourcePath("classAsWithInclusion"), queryParams,
@@ -141,7 +141,7 @@ public class IncludedRelationshipExtractorTest {
     @Test
     public void onInclusionShouldReturnOneElement() throws Exception {
         // GIVEN
-        QueryParams queryParams = getRequestParamsWithInclusion("include[classAs]",
+        QueryParams queryParams = getRequestParamsWithInclusion("INCLUDE[classAs]",
             "classBs");
 
         ResourceResponse response = new ResourceResponse(null, new ResourcePath("classAs"), queryParams,
@@ -159,7 +159,7 @@ public class IncludedRelationshipExtractorTest {
     @Test
     public void onDifferentTypeInclusionShouldReturnNoElements() throws Exception {
         // GIVEN
-        QueryParams queryParams = getRequestParamsWithInclusion("include[classBsWith]",
+        QueryParams queryParams = getRequestParamsWithInclusion("INCLUDE[classBsWith]",
             "classCsWith");
 
         ResourceResponse response = new ResourceResponse(null, new ResourcePath("classAsWith"), queryParams,

--- a/src/test/java/io/katharsis/queryParams/DefaultQueryParamsParserTest.java
+++ b/src/test/java/io/katharsis/queryParams/DefaultQueryParamsParserTest.java
@@ -20,7 +20,7 @@ public class DefaultQueryParamsParserTest {
     @Test
     public void onGivenFiltersParserShouldReturnOnlyRequestParamsWithFilters() {
         // GIVEN
-        queryParams.put("filter[users][name]", Collections.singleton("John"));
+        queryParams.put("FILTER[users][name]", Collections.singleton("John"));
         queryParams.put("random[users][name]", Collections.singleton("John"));
 
         // WHEN
@@ -28,29 +28,29 @@ public class DefaultQueryParamsParserTest {
 
         // THEN
         assertThat(result.entrySet().size()).isEqualTo(1);
-        assertThat(result.entrySet().iterator().next().getKey().startsWith("filter"));
+        assertThat(result.entrySet().iterator().next().getKey().startsWith("FILTER"));
         assertThat(result.entrySet().iterator().next().getValue().equals(Collections.singleton("John")));
     }
 
     @Test
     public void onGivenSortingParserShouldReturnOnlyRequestParamsWithSorting() {
         // GIVEN
-        queryParams.put("sort[users][name]", Collections.singleton("asc"));
-        queryParams.put("random[users][name]", Collections.singleton("desc"));
+        queryParams.put("SORT[users][name]", Collections.singleton("ASC"));
+        queryParams.put("random[users][name]", Collections.singleton("DESC"));
 
         // WHEN
         Map<String, Set<String>> result = parser.parseSortingParameters(queryParams);
 
         // THEN
         assertThat(result.entrySet().size()).isEqualTo(1);
-        assertThat(result.entrySet().iterator().next().getKey().startsWith("sort"));
-        assertThat(result.entrySet().iterator().next().getValue().equals(Collections.singleton("asc")));
+        assertThat(result.entrySet().iterator().next().getKey().startsWith("SORT"));
+        assertThat(result.entrySet().iterator().next().getValue().equals(Collections.singleton("ASC")));
     }
 
     @Test
     public void onGivenGroupingParserShouldReturnOnlyRequestParamsWithGrouping() {
         // GIVEN
-        queryParams.put("group[users]", Collections.singleton("name"));
+        queryParams.put("GROUP[users]", Collections.singleton("name"));
         queryParams.put("random[users]", Collections.singleton("surname"));
 
         // WHEN
@@ -58,32 +58,32 @@ public class DefaultQueryParamsParserTest {
 
         // THEN
         assertThat(result.entrySet().size()).isEqualTo(1);
-        assertThat(result.entrySet().iterator().next().getKey().startsWith("group"));
+        assertThat(result.entrySet().iterator().next().getKey().startsWith("GROUP"));
         assertThat(result.entrySet().iterator().next().getValue().equals(Collections.singleton("name")));
     }
 
     @Test
     public void onGivenPaginationParserShouldReturnOnlyRequestParamsWithPagination() {
         // GIVEN
-        queryParams.put("page[offset]", Collections.singleton("1"));
-        queryParams.put("page[limit]", Collections.singleton("10"));
-        queryParams.put("random[offset]", Collections.singleton("2"));
-        queryParams.put("random[limit]", Collections.singleton("20"));
+        queryParams.put("PAGE[OFFSET]", Collections.singleton("1"));
+		queryParams.put("PAGE[LIMIT]", Collections.singleton("10"));
+        queryParams.put("random[OFFSET]", Collections.singleton("2"));
+        queryParams.put("random[LIMIT]", Collections.singleton("20"));
 
         // WHEN
         Map<String, Set<String>> result = parser.parsePaginationParameters(queryParams);
 
         // THEN
         assertThat(result.entrySet().size()).isEqualTo(2);
-        assertThat(result.get("page[offset]").equals(Collections.singleton("1")));
-        assertThat(result.get("page[limit]").equals(Collections.singleton("10")));
+        assertThat(result.get("PAGE[OFFSET]").equals(Collections.singleton("1")));
+        assertThat(result.get("PAGE[LIMIT]").equals(Collections.singleton("10")));
     }
 
     ////////
     @Test
     public void onGivenIncludedFieldsParserShouldReturnOnlyRequestParamsWithIncludedFields() {
         // GIVEN
-        queryParams.put("fields[users]", Collections.singleton("name"));
+        queryParams.put("FIELDS[users]", Collections.singleton("name"));
         queryParams.put("random[users]", Collections.singleton("surname"));
 
         // WHEN
@@ -91,14 +91,14 @@ public class DefaultQueryParamsParserTest {
 
         // THEN
         assertThat(result.entrySet().size()).isEqualTo(1);
-        assertThat(result.entrySet().iterator().next().getKey().startsWith("fields"));
+		assertThat(result.entrySet().iterator().next().getKey().startsWith("FIELDS"));
         assertThat(result.entrySet().iterator().next().getValue().equals(Collections.singleton("name")));
     }
 
     @Test
     public void onGivenIncludedRelationsParserShouldReturnOnlyRequestParamsWithIncludedRelations() {
         // GIVEN
-        queryParams.put("include[user]", Collections.singleton("name"));
+        queryParams.put("INCLUDE[user]", Collections.singleton("name"));
         queryParams.put("random[user]", Collections.singleton("surname"));
 
         // WHEN
@@ -106,7 +106,7 @@ public class DefaultQueryParamsParserTest {
 
         // THEN
         assertThat(result.entrySet().size()).isEqualTo(1);
-        assertThat(result.entrySet().iterator().next().getKey().startsWith("include"));
+        assertThat(result.entrySet().iterator().next().getKey().startsWith("INCLUDE"));
         assertThat(result.entrySet().iterator().next().getValue().equals(Collections.singleton("name")));
     }
 

--- a/src/test/java/io/katharsis/queryParams/QueryParamsBuilderTest.java
+++ b/src/test/java/io/katharsis/queryParams/QueryParamsBuilderTest.java
@@ -25,7 +25,7 @@ public class QueryParamsBuilderTest {
     @Test
     public void onGivenFiltersBuilderShouldReturnRequestParamsWithFilters() throws ParametersDeserializationException {
         // GIVEN
-        queryParams.put("filter[users][name]", Collections.singleton("John"));
+        queryParams.put("FILTER[users][name]", Collections.singleton("John"));
 
         // WHEN
         QueryParams result = sut.buildQueryParams(queryParams);
@@ -45,7 +45,7 @@ public class QueryParamsBuilderTest {
     @Test
     public void onGivenSortingBuilderShouldReturnRequestParamsWithSorting() throws ParametersDeserializationException {
         // GIVEN
-        queryParams.put("sort[users][name]", Collections.singleton("asc"));
+        queryParams.put("SORT[users][name]", Collections.singleton("ASC"));
 
         // WHEN
         QueryParams result = sut.buildQueryParams(queryParams);
@@ -59,7 +59,7 @@ public class QueryParamsBuilderTest {
             .getParams()
             .get("users")
             .getParams()
-            .get("name")).isEqualTo(RestrictedSortingValues.asc);
+            .get("name")).isEqualTo(RestrictedSortingValues.ASC);
 
     }
 
@@ -67,7 +67,7 @@ public class QueryParamsBuilderTest {
     public void onGivenGroupingBuilderShouldReturnRequestParamsWithGrouping() throws
         ParametersDeserializationException {
         // GIVEN
-        queryParams.put("group[users]", Collections.singleton("name"));
+        queryParams.put("GROUP[users]", Collections.singleton("name"));
 
         // WHEN
         QueryParams result = sut.buildQueryParams(queryParams);
@@ -90,24 +90,24 @@ public class QueryParamsBuilderTest {
     public void onGivenPaginationBuilderShouldReturnRequestParamsWithPagination() throws
         ParametersDeserializationException {
         // GIVEN
-        queryParams.put("page[offset]", Collections.singleton("0"));
-        queryParams.put("page[limit]", Collections.singleton("10"));
+        queryParams.put("PAGE[OFFSET]", Collections.singleton("0"));
+        queryParams.put("PAGE[LIMIT]", Collections.singleton("10"));
 
         // WHEN
         QueryParams result = sut.buildQueryParams(queryParams);
 
         // THEN
         assertThat(result.getPagination()
-            .get(RestrictedPaginationKeys.offset)).isEqualTo(0);
+            .get(RestrictedPaginationKeys.OFFSET)).isEqualTo(0);
         assertThat(result.getPagination()
-            .get(RestrictedPaginationKeys.limit)).isEqualTo(10);
+            .get(RestrictedPaginationKeys.LIMIT)).isEqualTo(10);
     }
 
     @Test
     public void onGivenIncludedFieldsBuilderShouldReturnRequestParamsWithIncludedFields() throws
         ParametersDeserializationException {
         // GIVEN
-        queryParams.put("fields[users]", Collections.singleton("name"));
+        queryParams.put("FIELDS[users]", Collections.singleton("name"));
 
         // WHEN
         QueryParams result = sut.buildQueryParams(queryParams);
@@ -129,7 +129,7 @@ public class QueryParamsBuilderTest {
     public void onGivenIncludedRelationsBuilderShouldReturnRequestParamsWithIncludedRelations() throws
         ParametersDeserializationException {
         // GIVEN
-        queryParams.put("include[special-users]", Collections.singleton("friends"));
+        queryParams.put("INCLUDE[special-users]", Collections.singleton("friends"));
 
         // WHEN
         QueryParams result = sut.buildQueryParams(queryParams);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00115
Constant names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00115
Please let me know if you have any questions.
George Kankava