### PR TITLE
squid:S00122 Statements should be on separate lines

### DIFF
--- a/src/main/java/io/katharsis/errorhandling/ErrorData.java
+++ b/src/main/java/io/katharsis/errorhandling/ErrorData.java
@@ -114,8 +114,12 @@ public final class ErrorData {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ErrorData)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ErrorData)) {
+            return false;
+        }
         ErrorData that = (ErrorData) o;
         return Objects.equals(id, that.id) &&
                 Objects.equals(aboutLink, that.aboutLink) &&

--- a/src/main/java/io/katharsis/errorhandling/ErrorResponse.java
+++ b/src/main/java/io/katharsis/errorhandling/ErrorResponse.java
@@ -58,8 +58,12 @@ public final class ErrorResponse implements BaseResponse<Iterable<ErrorData>> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ErrorResponse)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ErrorResponse)) {
+            return false;
+        }
         ErrorResponse that = (ErrorResponse) o;
         return Objects.equals(httpStatus, that.httpStatus) &&
                 Objects.equals(data, that.data);

--- a/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperType.java
+++ b/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperType.java
@@ -21,8 +21,12 @@ final class ExceptionMapperType {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ExceptionMapperType)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ExceptionMapperType)) {
+            return false;
+        }
         ExceptionMapperType that = (ExceptionMapperType) o;
         return Objects.equals(exceptionMapper, that.exceptionMapper) &&
                 Objects.equals(exceptionClass, that.exceptionClass);

--- a/src/main/java/io/katharsis/queryParams/include/Inclusion.java
+++ b/src/main/java/io/katharsis/queryParams/include/Inclusion.java
@@ -28,8 +28,12 @@ public class Inclusion {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Inclusion inclusion = (Inclusion) o;
 

--- a/src/main/java/io/katharsis/request/path/JsonPath.java
+++ b/src/main/java/io/katharsis/request/path/JsonPath.java
@@ -91,8 +91,12 @@ public abstract class JsonPath {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         JsonPath jsonPath = (JsonPath) o;
         return Objects.equals(elementName, jsonPath.elementName) &&
                 Objects.equals(ids, jsonPath.ids) &&

--- a/src/main/java/io/katharsis/request/path/PathIds.java
+++ b/src/main/java/io/katharsis/request/path/PathIds.java
@@ -26,8 +26,12 @@ public class PathIds {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         PathIds pathIds = (PathIds) o;
 

--- a/src/main/java/io/katharsis/resource/registry/RegistryEntry.java
+++ b/src/main/java/io/katharsis/resource/registry/RegistryEntry.java
@@ -112,8 +112,12 @@ public class RegistryEntry<T> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         RegistryEntry<?> that = (RegistryEntry<?>) o;
         return Objects.equals(resourceInformation, that.resourceInformation) &&
             Objects.equals(resourceEntry, that.resourceEntry) &&

--- a/src/main/java/io/katharsis/response/CollectionResponse.java
+++ b/src/main/java/io/katharsis/response/CollectionResponse.java
@@ -76,8 +76,12 @@ public class CollectionResponse implements BaseResponse<Iterable> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         CollectionResponse that = (CollectionResponse) o;
         return Objects.equals(data, that.data);
     }

--- a/src/main/java/io/katharsis/response/Container.java
+++ b/src/main/java/io/katharsis/response/Container.java
@@ -39,8 +39,12 @@ public class Container {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Container container = (Container) o;
         return Objects.equals(data, container.data);
     }

--- a/src/main/java/io/katharsis/response/DataLinksContainer.java
+++ b/src/main/java/io/katharsis/response/DataLinksContainer.java
@@ -39,8 +39,12 @@ public class DataLinksContainer {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         DataLinksContainer that = (DataLinksContainer) o;
         return Objects.equals(data, that.data) &&
                 Objects.equals(relationshipFields, that.relationshipFields);

--- a/src/main/java/io/katharsis/response/LinkageContainer.java
+++ b/src/main/java/io/katharsis/response/LinkageContainer.java
@@ -45,8 +45,12 @@ public class LinkageContainer {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         LinkageContainer that = (LinkageContainer) o;
         return Objects.equals(objectItem, that.objectItem) &&
                 Objects.equals(relationshipClass, that.relationshipClass) &&

--- a/src/main/java/io/katharsis/response/RelationshipContainer.java
+++ b/src/main/java/io/katharsis/response/RelationshipContainer.java
@@ -39,8 +39,12 @@ public class RelationshipContainer {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         RelationshipContainer that = (RelationshipContainer) o;
         return Objects.equals(dataLinksContainer, that.dataLinksContainer) &&
                 Objects.equals(relationshipField, that.relationshipField);

--- a/src/main/java/io/katharsis/response/ResourceResponse.java
+++ b/src/main/java/io/katharsis/response/ResourceResponse.java
@@ -84,8 +84,12 @@ public class ResourceResponse implements BaseResponse {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         ResourceResponse that = (ResourceResponse) o;
         return Objects.equals(data, that.data);
     }

--- a/src/main/java/io/katharsis/utils/ClassUtils.java
+++ b/src/main/java/io/katharsis/utils/ClassUtils.java
@@ -206,7 +206,9 @@ public class ClassUtils {
             return false;
         if (method.getName().length() < 3)
             return false;
-        if (method.getParameterTypes().length != 0) return false;
+        if (method.getParameterTypes().length != 0) {
+            return false;
+        }
         return boolean.class.equals(method.getReturnType()) || Boolean.class.equals(method.getReturnType());
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00122 Statements should be on separate lines.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
Please let me know if you have any questions.
George Kankava