### PR TITLE
"private" methods that don't access instance data should be "static"

### DIFF
--- a/src/main/java/io/katharsis/dispatcher/controller/resource/ResourceUpsert.java
+++ b/src/main/java/io/katharsis/dispatcher/controller/resource/ResourceUpsert.java
@@ -119,7 +119,7 @@ public abstract class ResourceUpsert extends BaseController {
         relationshipRepository.setRelations(savedResource, castedRelationIds, relationshipField.getUnderlyingName());
     }
 
-    private boolean allTypesTheSame(Iterable<LinkageData> linkages) {
+    private static boolean allTypesTheSame(Iterable<LinkageData> linkages) {
         String type = linkages.iterator()
             .hasNext() ? linkages.iterator()
             .next()

--- a/src/main/java/io/katharsis/dispatcher/registry/ControllerRegistryBuilder.java
+++ b/src/main/java/io/katharsis/dispatcher/registry/ControllerRegistryBuilder.java
@@ -47,7 +47,7 @@ public class ControllerRegistryBuilder {
      * @return an instance of {@link ControllerRegistry} with initialized controllers
      * @throws Exception initialization exception
      */
-    private ControllerRegistry build(ControllerLookup lookup) throws Exception {
+    private static ControllerRegistry build(ControllerLookup lookup) throws Exception {
         List<BaseController> controllers = new LinkedList<>();
         controllers.addAll(lookup.getControllers());
         return new ControllerRegistry(controllers);

--- a/src/main/java/io/katharsis/jackson/serializer/ContainerSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/ContainerSerializer.java
@@ -110,7 +110,7 @@ public class ContainerSerializer extends JsonSerializer<Container> {
      * The id MUST be written as a string
      * <a href="http://jsonapi.org/format/#document-structure-resource-ids">Resource IDs</a>.
      */
-    private void writeId(JsonGenerator gen, Object data, ResourceField idField)
+    private static void writeId(JsonGenerator gen, Object data, ResourceField idField)
         throws IllegalAccessException, InvocationTargetException, NoSuchMethodException, IOException {
         String sourceId = BeanUtils.getProperty(data, idField.getUnderlyingName());
         gen.writeObjectField(ID_FIELD_NAME, sourceId);
@@ -142,7 +142,7 @@ public class ContainerSerializer extends JsonSerializer<Container> {
         }
     }
 
-    private IncludedFieldsParams findIncludedFields(TypedParams<IncludedFieldsParams> includedFields, String
+    private static IncludedFieldsParams findIncludedFields(TypedParams<IncludedFieldsParams> includedFields, String
         elementName) {
         IncludedFieldsParams includedFieldsParams = null;
         if (includedFields != null) {
@@ -156,7 +156,7 @@ public class ContainerSerializer extends JsonSerializer<Container> {
         return includedFieldsParams;
     }
 
-    private void writeRelationshipFields(JsonGenerator gen, Object data, Set<ResourceField> relationshipFields)
+    private static void writeRelationshipFields(JsonGenerator gen, Object data, Set<ResourceField> relationshipFields)
         throws IOException {
         DataLinksContainer dataLinksContainer = new DataLinksContainer(data, relationshipFields);
         gen.writeObjectField(RELATIONSHIPS_FIELD_NAME, dataLinksContainer);

--- a/src/main/java/io/katharsis/jackson/serializer/ErrorResponseSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/ErrorResponseSerializer.java
@@ -61,13 +61,13 @@ public class ErrorResponseSerializer extends JsonSerializer<ErrorResponse> {
         gen.writeEndObject();
     }
 
-    private void writeMeta(ErrorData errorData, JsonGenerator gen) throws IOException {
+    private static void writeMeta(ErrorData errorData, JsonGenerator gen) throws IOException {
         if (errorData.getMeta() != null) {
             gen.writeObjectField(META, errorData.getMeta());
         }
     }
 
-    private void writeSource(ErrorData errorData, JsonGenerator gen) throws IOException {
+    private static void writeSource(ErrorData errorData, JsonGenerator gen) throws IOException {
         if (errorData.getSourceParameter() != null || errorData.getSourcePointer() != null) {
             gen.writeObjectFieldStart(SOURCE);
             writeStringIfExists(POINTER, errorData.getSourcePointer(), gen);
@@ -76,7 +76,7 @@ public class ErrorResponseSerializer extends JsonSerializer<ErrorResponse> {
         }
     }
 
-    private void writeAboutLink(ErrorData errorData, JsonGenerator gen) throws IOException {
+    private static void writeAboutLink(ErrorData errorData, JsonGenerator gen) throws IOException {
         if (errorData.getAboutLink() != null) {
             gen.writeObjectFieldStart(LINKS);
             gen.writeStringField(ABOUT_LINK, errorData.getAboutLink());

--- a/src/main/java/io/katharsis/jackson/serializer/IncludedRelationshipExtractor.java
+++ b/src/main/java/io/katharsis/jackson/serializer/IncludedRelationshipExtractor.java
@@ -108,7 +108,7 @@ public class IncludedRelationshipExtractor {
         return includedResources;
     }
 
-    private IncludedRelationsParams findInclusions(TypedParams<IncludedRelationsParams> queryParams,
+    private static IncludedRelationsParams findInclusions(TypedParams<IncludedRelationsParams> queryParams,
                                                    String resourceName) {
         if (queryParams != null && queryParams.getParams() != null) {
             for (Map.Entry<String, IncludedRelationsParams> entry : queryParams.getParams()

--- a/src/main/java/io/katharsis/jackson/serializer/LinkageContainerSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/LinkageContainerSerializer.java
@@ -44,7 +44,7 @@ public class LinkageContainerSerializer extends JsonSerializer<LinkageContainer>
         gen.writeObjectField(TYPE_FIELD_NAME, resourceType);
     }
 
-    private void writeId(JsonGenerator gen, LinkageContainer linkageContainer)
+    private static void writeId(JsonGenerator gen, LinkageContainer linkageContainer)
             throws IllegalAccessException, InvocationTargetException, NoSuchMethodException, IOException {
         ResourceField idField = linkageContainer.getRelationshipEntry().getResourceInformation().getIdField();
         String sourceId = BeanUtils.getProperty(linkageContainer.getObjectItem(), idField.getUnderlyingName());

--- a/src/main/java/io/katharsis/jackson/serializer/RelationshipContainerSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/RelationshipContainerSerializer.java
@@ -100,7 +100,7 @@ public class RelationshipContainerSerializer extends JsonSerializer<Relationship
         }
     }
 
-    private void writeToManyLinkage(RelationshipContainer relationshipContainer, JsonGenerator gen,
+    private static void writeToManyLinkage(RelationshipContainer relationshipContainer, JsonGenerator gen,
                                     Class relationshipClass, RegistryEntry relationshipEntry)
         throws IOException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         ResourceField relationshipField = relationshipContainer.getRelationshipField();
@@ -116,7 +116,7 @@ public class RelationshipContainerSerializer extends JsonSerializer<Relationship
         gen.writeEndArray();
     }
 
-    private void writeToOneLinkage(RelationshipContainer relationshipContainer, JsonGenerator gen,
+    private static void writeToOneLinkage(RelationshipContainer relationshipContainer, JsonGenerator gen,
                                    Class<?> relationshipClass, RegistryEntry relationshipEntry)
         throws IOException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         ResourceField relationshipField = relationshipContainer.getRelationshipField();

--- a/src/main/java/io/katharsis/queryParams/QueryParams.java
+++ b/src/main/java/io/katharsis/queryParams/QueryParams.java
@@ -342,7 +342,7 @@ public class QueryParams {
         this.includedRelations = new TypedParams<>(Collections.unmodifiableMap(decodedInclusions));
     }
 
-    private List<String> buildPropertyListFromEntry(Map.Entry<String, Set<String>> entry, String prefix) {
+    private static List<String> buildPropertyListFromEntry(Map.Entry<String, Set<String>> entry, String prefix) {
         String entryKey = entry.getKey()
             .substring(prefix.length());
 

--- a/src/main/java/io/katharsis/request/path/PathBuilder.java
+++ b/src/main/java/io/katharsis/request/path/PathBuilder.java
@@ -102,7 +102,7 @@ public class PathBuilder {
         throw new ResourceFieldNotFoundException(elementName);
     }
 
-    private PathIds createPathIds(String idsString) {
+    private static PathIds createPathIds(String idsString) {
         List<String> pathIds = Arrays.asList(idsString.split(PathIds.ID_SEPERATOR));
         return new PathIds(pathIds);
     }

--- a/src/main/java/io/katharsis/resource/include/IncludeLookupSetter.java
+++ b/src/main/java/io/katharsis/resource/include/IncludeLookupSetter.java
@@ -60,7 +60,7 @@ public class IncludeLookupSetter {
         }
     }
 
-    private IncludedRelationsParams findInclusions(TypedParams<IncludedRelationsParams> queryParams, String
+    private static IncludedRelationsParams findInclusions(TypedParams<IncludedRelationsParams> queryParams, String
         resourceName) {
         IncludedRelationsParams includedRelationsParams = null;
         for (Map.Entry<String, IncludedRelationsParams> entry : queryParams.getParams()

--- a/src/main/java/io/katharsis/resource/information/ResourceInformation.java
+++ b/src/main/java/io/katharsis/resource/information/ResourceInformation.java
@@ -58,7 +58,7 @@ public final class ResourceInformation {
         return getJsonField(name, relationshipFields);
     }
 
-    private ResourceField getJsonField(String name, Set<ResourceField> fields) {
+    private static ResourceField getJsonField(String name, Set<ResourceField> fields) {
         ResourceField foundField = null;
         for (ResourceField field : fields) {
             if (field.getJsonName().equals(name)) {

--- a/src/main/java/io/katharsis/resource/information/ResourceInformationBuilder.java
+++ b/src/main/java/io/katharsis/resource/information/ResourceInformationBuilder.java
@@ -124,7 +124,7 @@ public final class ResourceInformationBuilder {
         return resourceFields;
     }
 
-    private boolean hasDiscardedField(ResourceFieldWrapper fieldWrapper, List<ResourceFieldWrapper> resourceClassFields) {
+    private static boolean hasDiscardedField(ResourceFieldWrapper fieldWrapper, List<ResourceFieldWrapper> resourceClassFields) {
         for (ResourceFieldWrapper resourceFieldWrapper : resourceClassFields) {
             if (fieldWrapper.getResourceField().getUnderlyingName()
                 .equals(resourceFieldWrapper.getResourceField().getUnderlyingName())) {
@@ -134,7 +134,7 @@ public final class ResourceInformationBuilder {
         return false;
     }
 
-    private ResourceField mergeAnnotations(ResourceField fromField, ResourceField fromMethod) {
+    private static ResourceField mergeAnnotations(ResourceField fromField, ResourceField fromMethod) {
         List<Annotation> annotations = new LinkedList<>(fromField.getAnnotations());
         annotations.addAll(fromMethod.getAnnotations());
 
@@ -181,7 +181,7 @@ public final class ResourceInformationBuilder {
         return relationshipFields;
     }
 
-    private Set<ResourceField> buildResourceFieldSet(Optional<JsonPropertyOrder> propertyOrderOptional) {
+    private static Set<ResourceField> buildResourceFieldSet(Optional<JsonPropertyOrder> propertyOrderOptional) {
         Set<ResourceField> basicFields;
         if (propertyOrderOptional.isPresent()) {
             JsonPropertyOrder propertyOrder = propertyOrderOptional.get();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2325 "private" methods that don't access instance data should be "static".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava