### PR TITLE
multiple code improvements: squid:S00105, squid:S1068, squid:S1155

### DIFF
--- a/src/main/java/io/katharsis/dispatcher/controller/collection/CollectionGet.java
+++ b/src/main/java/io/katharsis/dispatcher/controller/collection/CollectionGet.java
@@ -27,8 +27,6 @@ import java.util.List;
 
 public class CollectionGet extends ResourceIncludeField {
 
-    private static final transient Logger log = LoggerFactory.getLogger(CollectionGet.class);
-
     public CollectionGet(ResourceRegistry resourceRegistry, TypeParser typeParser, IncludeLookupSetter fieldSetter) {
         super(resourceRegistry, typeParser, fieldSetter);
     }

--- a/src/main/java/io/katharsis/dispatcher/registry/ControllerLookup.java
+++ b/src/main/java/io/katharsis/dispatcher/registry/ControllerLookup.java
@@ -9,8 +9,8 @@ import java.util.Set;
  */
 public interface ControllerLookup {
 
-	/**
-	 * @return the instances of the {@link BaseController}'s.
-	 */
-	Set<BaseController> getControllers();
+    /**
+     * @return the instances of the {@link BaseController}'s.
+     */
+    Set<BaseController> getControllers();
 }

--- a/src/main/java/io/katharsis/dispatcher/registry/DefaultControllerLookup.java
+++ b/src/main/java/io/katharsis/dispatcher/registry/DefaultControllerLookup.java
@@ -27,33 +27,33 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class DefaultControllerLookup implements ControllerLookup {
 
     private ResourceRegistry resourceRegistry;
-	private TypeParser typeParser;
-	private ObjectMapper objectMapper;
-	private IncludeLookupSetter includeFieldSetter;
+    private TypeParser typeParser;
+    private ObjectMapper objectMapper;
+    private IncludeLookupSetter includeFieldSetter;
 
-	public DefaultControllerLookup(ResourceRegistry resourceRegistry, TypeParser typeParser, ObjectMapper objectMapper, IncludeLookupSetter includeFieldSetter) {
-		this.resourceRegistry = resourceRegistry;
-		this.typeParser = typeParser;
-		this.objectMapper = objectMapper;
-		this.includeFieldSetter = includeFieldSetter;
-	}
-	
-	@Override
-	public Set<BaseController> getControllers() {
-		Set<BaseController> controllers = new HashSet<>();
-		controllers.add(new RelationshipsResourceDelete(resourceRegistry, typeParser));
-		controllers.add(new RelationshipsResourcePatch(resourceRegistry, typeParser));
-		controllers.add(new RelationshipsResourcePost(resourceRegistry, typeParser));
-		controllers.add(new ResourceDelete(resourceRegistry, typeParser));
-		controllers.add(new CollectionGet(resourceRegistry, typeParser, includeFieldSetter));
-		controllers.add(new FieldResourceGet(resourceRegistry, typeParser, includeFieldSetter));
-		controllers.add(new RelationshipsResourceGet(resourceRegistry, typeParser, includeFieldSetter));
-		controllers.add(new ResourceGet(resourceRegistry, typeParser, includeFieldSetter));
-		controllers.add(new FieldResourcePost(resourceRegistry, typeParser, objectMapper));
-		controllers.add(new ResourcePatch(resourceRegistry, typeParser, objectMapper));
-		controllers.add(new ResourcePost(resourceRegistry, typeParser, objectMapper));
+    public DefaultControllerLookup(ResourceRegistry resourceRegistry, TypeParser typeParser, ObjectMapper objectMapper, IncludeLookupSetter includeFieldSetter) {
+        this.resourceRegistry = resourceRegistry;
+        this.typeParser = typeParser;
+        this.objectMapper = objectMapper;
+        this.includeFieldSetter = includeFieldSetter;
+    }
 
-		return controllers;
-	}
+    @Override
+    public Set<BaseController> getControllers() {
+        Set<BaseController> controllers = new HashSet<>();
+        controllers.add(new RelationshipsResourceDelete(resourceRegistry, typeParser));
+        controllers.add(new RelationshipsResourcePatch(resourceRegistry, typeParser));
+        controllers.add(new RelationshipsResourcePost(resourceRegistry, typeParser));
+        controllers.add(new ResourceDelete(resourceRegistry, typeParser));
+        controllers.add(new CollectionGet(resourceRegistry, typeParser, includeFieldSetter));
+        controllers.add(new FieldResourceGet(resourceRegistry, typeParser, includeFieldSetter));
+        controllers.add(new RelationshipsResourceGet(resourceRegistry, typeParser, includeFieldSetter));
+        controllers.add(new ResourceGet(resourceRegistry, typeParser, includeFieldSetter));
+        controllers.add(new FieldResourcePost(resourceRegistry, typeParser, objectMapper));
+        controllers.add(new ResourcePatch(resourceRegistry, typeParser, objectMapper));
+        controllers.add(new ResourcePost(resourceRegistry, typeParser, objectMapper));
+
+        return controllers;
+    }
 
 }

--- a/src/main/java/io/katharsis/errorhandling/exception/KatharsisInitializationException.java
+++ b/src/main/java/io/katharsis/errorhandling/exception/KatharsisInitializationException.java
@@ -10,6 +10,6 @@ public class KatharsisInitializationException extends RuntimeException {
     }
     
     protected KatharsisInitializationException(String message, Exception e) {
-    	super(message, e);
+        super(message, e);
     }
 }

--- a/src/main/java/io/katharsis/queryParams/QueryParams.java
+++ b/src/main/java/io/katharsis/queryParams/QueryParams.java
@@ -352,7 +352,7 @@ public class QueryParams {
         }
 
 
-        if (matchList.size() < 1) {
+        if (matchList.isEmpty()) {
             throw new ParametersDeserializationException("Malformed filter parameter: " + entryKey);
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00105 - Tabulation characters should not be used.
squid:S1068 - Unused private fields should be removed.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00105
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava
