### PR TITLE
multiple code improvements: squid:S2325, squid:S1596, squid:UselessPa…

### DIFF
--- a/src/main/java/io/katharsis/jackson/serializer/BaseResponseSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/BaseResponseSerializer.java
@@ -88,7 +88,7 @@ public class BaseResponseSerializer extends JsonSerializer<BaseResponse> {
         if (value != null) {
             return includedRelationshipExtractor.extractIncludedResources(value, resourceResponse);
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/src/main/java/io/katharsis/jackson/serializer/ContainerSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/ContainerSerializer.java
@@ -170,7 +170,7 @@ public class ContainerSerializer extends JsonSerializer<Container> {
      * @param attributeField resource attribute field
      * @return <i>true</i> if it should be included in the response, <i>false</i> otherwise
      */
-    private boolean isIncluded(String resourceType, TypedParams<IncludedFieldsParams> includedFields, ResourceField attributeField) {
+    private static boolean isIncluded(String resourceType, TypedParams<IncludedFieldsParams> includedFields, ResourceField attributeField) {
         IncludedFieldsParams typeIncludedFields = findIncludedFields(includedFields, resourceType);
         if (typeIncludedFields == null || typeIncludedFields.getParams().isEmpty()) {
             return includedFields == null || includedFields.getParams().isEmpty();
@@ -223,7 +223,7 @@ public class ContainerSerializer extends JsonSerializer<Container> {
     /**
      Generate a new object mapper that ignore all fields except the specified
      */
-    private ObjectMapper getObjectMapper(JsonGenerator gen, Set<String> allowedFields) {
+    private static ObjectMapper getObjectMapper(JsonGenerator gen, Set<String> allowedFields) {
         ObjectMapper attributesObjectMapper = ((ObjectMapper)gen.getCodec())
             .copy();
         attributesObjectMapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector() {

--- a/src/main/java/io/katharsis/jackson/serializer/ErrorResponseSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/ErrorResponseSerializer.java
@@ -48,7 +48,7 @@ public class ErrorResponseSerializer extends JsonSerializer<ErrorResponse> {
         gen.writeEndArray();
     }
 
-    private void serializeErrorData(ErrorData errorData, JsonGenerator gen) throws IOException {
+    private static void serializeErrorData(ErrorData errorData, JsonGenerator gen) throws IOException {
         gen.writeStartObject();
         writeStringIfExists(ID, errorData.getId(), gen);
         writeAboutLink(errorData, gen);

--- a/src/main/java/io/katharsis/jackson/serializer/IncludedRelationshipExtractor.java
+++ b/src/main/java/io/katharsis/jackson/serializer/IncludedRelationshipExtractor.java
@@ -146,7 +146,7 @@ public class IncludedRelationshipExtractor {
         Object property = PropertyUtils.getProperty(resource, fieldName);
         if (property != null) {
             if (Iterable.class.isAssignableFrom(property.getClass())) {
-                for (Object o : ((Iterable) property)) {
+                for (Object o : (Iterable) property) {
                     //noinspection unchecked
                     elements.add(new Container(o, response));
                 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2325 - "private" methods that don't access instance data should be "static",
squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET,
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2325
https://dev.eclipse.org/sonar/rules/show/squid:S1596
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava