### PR TITLE
multiple code improvements: squid:S1068, squid:S2864, squid:S2325, squid:S1226, squid:S00105

### DIFF
--- a/src/main/java/io/katharsis/errorhandling/mapper/DefaultExceptionMapperLookup.java
+++ b/src/main/java/io/katharsis/errorhandling/mapper/DefaultExceptionMapperLookup.java
@@ -12,35 +12,35 @@ import org.reflections.Reflections;
  * are annotated with the {@link ExceptionMapperProvider} annotation.
  */
 public class DefaultExceptionMapperLookup implements ExceptionMapperLookup {
-	private String resourceSearchPackage;
+    private String resourceSearchPackage;
 
-	public DefaultExceptionMapperLookup(String resourceSearchPackage) {
-		this.resourceSearchPackage = resourceSearchPackage;
-	}
+    public DefaultExceptionMapperLookup(String resourceSearchPackage) {
+        this.resourceSearchPackage = resourceSearchPackage;
+    }
 
-	@Override
-	public Set<JsonApiExceptionMapper> getExceptionMappers() {
-		Reflections reflections;
-		if (resourceSearchPackage != null) {
-			String[] packageNames = resourceSearchPackage.split(",");
-			reflections = new Reflections(packageNames);
-		} else {
-			reflections = new Reflections(resourceSearchPackage);
-		}
-		Set<Class<?>> exceptionMapperClasses = reflections.getTypesAnnotatedWith(ExceptionMapperProvider.class);
+    @Override
+    public Set<JsonApiExceptionMapper> getExceptionMappers() {
+        Reflections reflections;
+        if (resourceSearchPackage != null) {
+            String[] packageNames = resourceSearchPackage.split(",");
+            reflections = new Reflections(packageNames);
+        } else {
+            reflections = new Reflections(resourceSearchPackage);
+        }
+        Set<Class<?>> exceptionMapperClasses = reflections.getTypesAnnotatedWith(ExceptionMapperProvider.class);
 
-		Set<JsonApiExceptionMapper> exceptionMappers = new HashSet<>();
-		for (Class<?> exceptionMapperClazz : exceptionMapperClasses) {
-			if (!JsonApiExceptionMapper.class.isAssignableFrom(exceptionMapperClazz)) {
-				throw new InvalidResourceException(exceptionMapperClazz.getCanonicalName() + " is not an implementation of JsonApiExceptionMapper");
-			}
-			try {
-				exceptionMappers.add((JsonApiExceptionMapper<? extends Throwable>) exceptionMapperClazz.newInstance());
-			} catch (Exception e) {
-				throw new InvalidResourceException(exceptionMapperClazz.getCanonicalName() + " can not be initialized", e);
-			}
-		}
-		return exceptionMappers;
-	}
+        Set<JsonApiExceptionMapper> exceptionMappers = new HashSet<>();
+        for (Class<?> exceptionMapperClazz : exceptionMapperClasses) {
+            if (!JsonApiExceptionMapper.class.isAssignableFrom(exceptionMapperClazz)) {
+                throw new InvalidResourceException(exceptionMapperClazz.getCanonicalName() + " is not an implementation of JsonApiExceptionMapper");
+            }
+            try {
+                exceptionMappers.add((JsonApiExceptionMapper<? extends Throwable>) exceptionMapperClazz.newInstance());
+            } catch (Exception e) {
+                throw new InvalidResourceException(exceptionMapperClazz.getCanonicalName() + " can not be initialized", e);
+            }
+        }
+        return exceptionMappers;
+    }
 
 }

--- a/src/main/java/io/katharsis/jackson/serializer/ContainerSerializer.java
+++ b/src/main/java/io/katharsis/jackson/serializer/ContainerSerializer.java
@@ -45,8 +45,6 @@ public class ContainerSerializer extends JsonSerializer<Container> {
     private static final String LINKS_FIELD_NAME = "links";
     private static final String SELF_FIELD_NAME = "self";
     private static final String JACKSON_ATTRIBUTE_FILTER_NAME = "katharsisFilter";
-    private static final TypeReference<Map<String, Object>> DEFAULT_MAP = new TypeReference<Map<String, Object>>() {
-    };
 
     private final ResourceRegistry resourceRegistry;
 
@@ -166,10 +164,9 @@ public class ContainerSerializer extends JsonSerializer<Container> {
         Map<String, Object> dataMap = om.convertValue(data, new TypeReference<Map<String, Object>>() {});
 
         Attributes attributesObject = new Attributes();
-        for(String key : dataMap.keySet()) {
-            Object value = dataMap.get(key);
-            if(value != null)
-                attributesObject.addAttribute(key, value);
+        for(Map.Entry<String,Object> entry : dataMap.entrySet()) {
+            if(entry.getValue() != null)
+                attributesObject.addAttribute(entry.getKey(), entry.getValue());
         }
 
         gen.writeObjectField(ATTRIBUTES_FIELD_NAME, attributesObject);
@@ -237,7 +234,7 @@ public class ContainerSerializer extends JsonSerializer<Container> {
     /**
      Generate a new object mapper and configure the filter to exclude some properties.
      */
-    private ObjectMapper getObjectMapper(JsonGenerator gen, final Object data, Set<String> includedFields) {
+    private static ObjectMapper getObjectMapper(JsonGenerator gen, final Object data, Set<String> includedFields) {
         ObjectMapper attributesObjectMapper = ((ObjectMapper)gen.getCodec())
             .copy();
 

--- a/src/main/java/io/katharsis/jackson/serializer/IncludedRelationshipExtractor.java
+++ b/src/main/java/io/katharsis/jackson/serializer/IncludedRelationshipExtractor.java
@@ -56,6 +56,7 @@ public class IncludedRelationshipExtractor {
 
 
     private List<?> getIncludedByDefaultResources(Object resource, int recurrenceLevel) {
+        int recurrenceLevelCounter = recurrenceLevel;
         if (recurrenceLevel >= 42 || resource == null) {
             return Collections.emptyList();
         }
@@ -70,20 +71,20 @@ public class IncludedRelationshipExtractor {
                 Object targetDataObj = PropertyUtils.getProperty(resource, resourceField.getUnderlyingName());
 
                 if (targetDataObj != null) {
-                    recurrenceLevel++;
+                    recurrenceLevelCounter++;
 
                     if (targetDataObj instanceof Iterable) {
                         for (Object objectItem : (Iterable) targetDataObj) {
                             //noinspection unchecked
                             includedFields.add(objectItem);
                             //noinspection unchecked
-                            includedFields.addAll(getIncludedByDefaultResources(objectItem, recurrenceLevel));
+                            includedFields.addAll(getIncludedByDefaultResources(objectItem, recurrenceLevelCounter));
                         }
                     } else {
                         //noinspection unchecked
                         includedFields.add(targetDataObj);
                         //noinspection unchecked
-                        includedFields.addAll(getIncludedByDefaultResources(targetDataObj, recurrenceLevel));
+                        includedFields.addAll(getIncludedByDefaultResources(targetDataObj, recurrenceLevelCounter));
                     }
                 }
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1068 - Unused private fields should be removed.
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:S2325 - "private" methods that don't access instance data should be "static".
squid:S1226 - Method parameters, caught exceptions and foreach variables should not be reassigned.
squid:S00105 - Tabulation characters should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S2325
https://dev.eclipse.org/sonar/rules/show/squid:S1226
https://dev.eclipse.org/sonar/rules/show/squid:S00105
Please let me know if you have any questions.
George Kankava