### PR TITLE
Multiple code improvements: squid:S00105, squid:S1226, squid:S1193, squid:S1700

### DIFF
--- a/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperLookup.java
+++ b/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperLookup.java
@@ -4,5 +4,5 @@ import java.util.Set;
 
 public interface ExceptionMapperLookup {
 
-	Set<JsonApiExceptionMapper> getExceptionMappers();
+    Set<JsonApiExceptionMapper> getExceptionMappers();
 }

--- a/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistry.java
+++ b/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistry.java
@@ -34,11 +34,12 @@ public final class ExceptionMapperRegistry {
 
     int getDistanceBetweenExceptions(Class<?> clazz, Class<?> mapperTypeClazz) {
         int distance = 0;
+        Class<?> superClazz = clazz;
         if (!mapperTypeClazz.isAssignableFrom(clazz))
             return Integer.MAX_VALUE;
 
-        while (clazz != mapperTypeClazz) {
-            clazz = clazz.getSuperclass();
+        while (superClazz != mapperTypeClazz) {
+            superClazz = superClazz.getSuperclass();
             distance++;
         }
         return distance;

--- a/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryBuilder.java
+++ b/src/main/java/io/katharsis/errorhandling/mapper/ExceptionMapperRegistryBuilder.java
@@ -8,21 +8,20 @@ import java.util.Set;
 public final class ExceptionMapperRegistryBuilder {
     private final Set<ExceptionMapperType> exceptionMappers = new HashSet<>();
 
-
     public Set<ExceptionMapperType> getExceptionMappers() {
         return exceptionMappers;
     }
-    
+
     public ExceptionMapperRegistry build(String resourceSearchPackage) throws IllegalAccessException, InstantiationException {
         return build(new DefaultExceptionMapperLookup(resourceSearchPackage));
     }
-    
+
     public ExceptionMapperRegistry build(ExceptionMapperLookup exceptionMapperLookup) throws IllegalAccessException, InstantiationException {
-    	addKatharsisDefaultMappers();
+        addKatharsisDefaultMappers();
         for (JsonApiExceptionMapper<?> exceptionMapper : exceptionMapperLookup.getExceptionMappers()) {
             registerExceptionMapper(exceptionMapper);
         }
-    	return new ExceptionMapperRegistry(exceptionMappers);
+        return new ExceptionMapperRegistry(exceptionMappers);
     }
 
     private void addKatharsisDefaultMappers() {

--- a/src/main/java/io/katharsis/queryParams/QueryParamsBuilder.java
+++ b/src/main/java/io/katharsis/queryParams/QueryParamsBuilder.java
@@ -42,14 +42,11 @@ public class QueryParamsBuilder {
             deserializedQueryParams.setPagination(this.queryParamsParser.parsePaginationParameters(queryParams));
             deserializedQueryParams.setIncludedFields(this.queryParamsParser.parseIncludedFieldsParameters(queryParams));
             deserializedQueryParams.setIncludedRelations(this.queryParamsParser.parseIncludedRelationsParameters(queryParams));
+        } catch (KatharsisException e) {
+            throw e;
         } catch (RuntimeException e) {
-            if (e instanceof KatharsisException) {
-                throw e;
-            } else {
-                throw new ParametersDeserializationException(e.getMessage());
-            }
+            throw new ParametersDeserializationException(e.getMessage());
         }
-
         return deserializedQueryParams;
     }
 }

--- a/src/main/java/io/katharsis/request/dto/Attributes.java
+++ b/src/main/java/io/katharsis/request/dto/Attributes.java
@@ -7,15 +7,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class Attributes {
-    private final Map<String, Object> attributes = new HashMap<>();
+    private final Map<String, Object> attributesMap = new HashMap<>();
 
     @JsonAnyGetter
-    public Map<String, Object> getAttributes() {
-        return this.attributes;
+    public Map<String, Object> getAttributesMap() {
+        return this.attributesMap;
     }
 
     @JsonAnySetter
     public void addAttribute(String name, Object value) {
-        this.attributes.put(name, value);
+        this.attributesMap.put(name, value);
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00105 - Tabulation characters should not be used.
squid:S1226 - Method parameters, caught exceptions and foreach variables should not be reassigned.
squid:S1193 - Exception types should not be tested using "instanceof" in catch blocks.
squid:S1700 - A field should not duplicate the name of its containing class.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00105
https://dev.eclipse.org/sonar/rules/show/squid:S1226
https://dev.eclipse.org/sonar/rules/show/squid:S1193
https://dev.eclipse.org/sonar/rules/show/squid:S1700
Please let me know if you have any questions.
George Kankava