### PR TITLE
add option to overwrite an included value with the value of the relationship repository

### DIFF
--- a/src/main/java/io/katharsis/resource/annotations/JsonApiLookupIncludeAutomatically.java
+++ b/src/main/java/io/katharsis/resource/annotations/JsonApiLookupIncludeAutomatically.java
@@ -16,4 +16,11 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
 public @interface JsonApiLookupIncludeAutomatically {
+
+    /**
+     * Defines whether Katharsis should overwrite the value of the related object on the resource when setting inclusions
+     *
+     * @return true if the related object field is to be overwritten, false otherwise
+     */
+    boolean overwrite() default false;
 }

--- a/src/main/java/io/katharsis/resource/include/IncludeLookupSetter.java
+++ b/src/main/java/io/katharsis/resource/include/IncludeLookupSetter.java
@@ -82,8 +82,9 @@ public class IncludeLookupSetter {
                 return;
             }
             Object property = PropertyUtils.getProperty(resource, field.getName());
-            //attempt to load relationship if it's null
-            if (property == null && field.isAnnotationPresent(JsonApiLookupIncludeAutomatically.class)) {
+            //attempt to load relationship if it's null or JsonApiLookupIncludeAutomatically.overwrite() == true
+            if (field.isAnnotationPresent(JsonApiLookupIncludeAutomatically.class)
+                    && (property == null || field.getAnnotation(JsonApiLookupIncludeAutomatically.class).overwrite())) {
                 try {
                     property = loadRelationship(resource, field, queryParams, parameterProvider);
                     PropertyUtils.setProperty(resource, field.getName(), property);


### PR DESCRIPTION
Given the following resource classes:
``` java
@JsonApiResource(type = "tasks")
public class Task {

    @JsonApiId
    private Long id;
    
    @JsonApiToOne
    @JsonApiLookupIncludeAutomatically
    private Project project;
}

@JsonApiResource(type = "projects")
public class Project {

    @JsonApiId
    private Long id;

    private String name;
}
```

TaskRepository (from jersey example, thrown into simple dropwizard example):
``` java
public class TaskRepository implements ResourceRepository<Task, Long> {
    @Override
    public <S extends Task> S save(S entity) {
        return null;
    }

    @Override
    public Task findOne(Long aLong, QueryParams requestParams) {
        Task task = new Task(aLong, "Some task");
        Project project = new Project();
        project.setId(aLong);
        task.setProject(project);
        return task;
    }

    ...
}
```

TaskToProjectRepository (from jersey example, thrown into simple dropwizard example):
``` java
@JsonApiRelationshipRepository(source = Task.class, target = Project.class)
public class TaskToProjectRepository {

    ...

    @JsonApiFindOneTarget
    public Project findOneTarget(Long sourceId, String fieldName, QueryParams requestParams) {
        Project project = new Project();
        project.setId(123L);
        project.setName("Request scoped value");
        return project;
    }
}
```
To fetch the Task resource with the project included, the url would be:
```
http://localhost:8080/tasks?include[tasks]=project
```

### Expected Output

The resource will be fetched and the project relationship will be added in the included list. The value of the included resource should be the value of TaskToProjectRepository.findOneTarget. We can verify this by seeing if the name attribute is set on the included resource, since only the relationship repo deals with it.

``` json
{
  "data": {
    "type": "tasks",
    "id": "1234",
    "attributes": {
      "name": "Some task"
    },
    "relationships": {
      "project": {
        "links": {
          "self": "http://localhost:8080/tasks/1234/relationships/project",
          "related": "http://localhost:8080/tasks/1234/project"
        },
        "data": {
          "type": "projects",
          "id": "123"
        }
      }
    },
    "links": {
      "self": "http://localhost:8080/tasks/1234"
    }
  },
  "included": [
    {
      "type": "projects",
      "id": "123",
      "attributes": {
        "name": "Request scoped value"
      },
      "relationships": {},
      "links": {
        "self": "http://localhost:8080/projects/123"
      }
    }
  ]
}
```

### Actual Output
``` json
{
  "data": {
    "type": "tasks",
    "id": "1234",
    "attributes": {
      "name": "Some task"
    },
    "relationships": {
      "project": {
        "links": {
          "self": "http://localhost:8080/tasks/1234/relationships/project",
          "related": "http://localhost:8080/tasks/1234/project"
        },
        "data": {
          "type": "projects",
          "id": "1234"
        }
      }
    },
    "links": {
      "self": "http://localhost:8080/tasks/1234"
    }
  },
  "included": [
    {
      "type": "projects",
      "id": "1234",
      "attributes": {},
      "relationships": {},
      "links": {
        "self": "http://localhost:8080/projects/1234"
      }
    }
  ]
}
```

### Conclusion

The included object in the actual output is not overwritten by the value of the relationship repo as I would have expected (i.e. the name attribute was not included). Upon further investigation, this is the offending line: https://github.com/katharsis-project/katharsis-core/blob/development/src/main/java/io/katharsis/resource/include/IncludeLookupSetter.java#L86
``` java
//attempt to load relationship if it's null
if (property == null && field.isAnnotationPresent(JsonApiLookupIncludeAutomatically.class))
```
So the framework will only load the relationship if the object hasn't been set yet. However, the TaskRepository above will set the project and its id. This means if the client tries to include the project, it will only receive what the TaskRepository sets.

Why not just null the project and let the relationship repo do its job?

If I null the project property on the Task in the repo method, and the client simply fetches the resource with no include parameter, the relationship shows up as this:
``` json
"relationships": {
      "project": {
        "links": {
          "self": "http://localhost:8080/tasks/1234/relationships/project",
          "related": "http://localhost:8080/tasks/1234/project"
        },
        "data": null
      }
    }
```

What bothers me is the null data object. I want to be able to provide the id and type in the data object of the relationship, even when the include parameter is not used. Therefore, I need to set related object and its id in the resource repository, but that means the included value will be incomplete when the client does use the include param, since the relationship repo won't be invoked.

### My solution

Add a flag to the JsonApiLookupIncludeAutomatically annotation, so we can specify if we want the included object overwritten when the include param is used. This way we can provide the minimal data to the client about the relationship resource prior to it being included.