### PR TITLE
Preventing a NullPointerException from being thrown when an invalid r…

### DIFF
--- a/src/main/java/io/katharsis/dispatcher/controller/resource/ResourceUpsert.java
+++ b/src/main/java/io/katharsis/dispatcher/controller/resource/ResourceUpsert.java
@@ -229,6 +229,10 @@ public abstract class ResourceUpsert extends BaseController {
         ResourceField relationshipFieldByName = registryEntry.getResourceInformation()
                 .findRelationshipFieldByName(property.getKey());
 
+        if(relationshipFieldByName == null) {
+            throw new ResourceException(String.format("Invalid relationship name: %s", property.getKey()));
+        }
+
         Object relationObject;
         if (property.getValue() != null) {
             RegistryEntry entry = resourceRegistry.getEntry(relationshipFieldByName.getType());


### PR DESCRIPTION
…elationship name is received. Instead, throwing a ResourceException with a helpful message about the invalid relationship name.