### PR TITLE
#365: Introduce a QueryParamsHelper to ease working with QueryParams

### DIFF
--- a/src/main/java/io/katharsis/queryParams/include/Inclusion.java
+++ b/src/main/java/io/katharsis/queryParams/include/Inclusion.java
@@ -46,10 +46,12 @@ public class Inclusion {
         return path != null ? path.hashCode() : 0;
     }
 
+    /**
+     * Returns the path of the resource to include, in fact returning the
+     * value of an include[...] parameter
+     */
     @Override
     public String toString() {
-        return "Inclusion{" +
-            "path='" + path + '\'' +
-            '}';
+        return path;
     }
 }

--- a/src/main/java/io/katharsis/queryParams/params/FilterParams.java
+++ b/src/main/java/io/katharsis/queryParams/params/FilterParams.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class FilterParams {
+public class FilterParams implements TwoDimensionalQueryParam<String> {
     private Map<String, Set<String>> params = new HashMap<>();
 
     public FilterParams(Map<String, Set<String>> params) {

--- a/src/main/java/io/katharsis/queryParams/params/GroupingParams.java
+++ b/src/main/java/io/katharsis/queryParams/params/GroupingParams.java
@@ -3,7 +3,7 @@ package io.katharsis.queryParams.params;
 import java.util.HashSet;
 import java.util.Set;
 
-public class GroupingParams {
+public class GroupingParams implements OneDimensionalQueryParam<String> {
     private Set<String> params = new HashSet<>();
 
     public GroupingParams(Set<String> params) {

--- a/src/main/java/io/katharsis/queryParams/params/IncludedFieldsParams.java
+++ b/src/main/java/io/katharsis/queryParams/params/IncludedFieldsParams.java
@@ -2,7 +2,7 @@ package io.katharsis.queryParams.params;
 
 import java.util.Set;
 
-public class IncludedFieldsParams {
+public class IncludedFieldsParams implements OneDimensionalQueryParam<String> {
     private Set<String> params;
 
     public IncludedFieldsParams(Set<String> params) {

--- a/src/main/java/io/katharsis/queryParams/params/IncludedRelationsParams.java
+++ b/src/main/java/io/katharsis/queryParams/params/IncludedRelationsParams.java
@@ -4,7 +4,7 @@ import io.katharsis.queryParams.include.Inclusion;
 
 import java.util.Set;
 
-public class IncludedRelationsParams {
+public class IncludedRelationsParams implements OneDimensionalQueryParam<Inclusion> {
     private Set<Inclusion> params;
 
     public IncludedRelationsParams(Set<Inclusion> params) {

--- a/src/main/java/io/katharsis/queryParams/params/OneDimensionalQueryParam.java
+++ b/src/main/java/io/katharsis/queryParams/params/OneDimensionalQueryParam.java
@@ -1,0 +1,17 @@
+package io.katharsis.queryParams.params;
+
+import java.util.Set;
+
+import io.katharsis.queryParams.include.Inclusion;
+
+/**
+ * Interface  for any filter that uses a one-dimensional string-indexed array in the parameter name.<br/>
+ * Eg. group[...]
+ *
+ * @param <P> Type of the parameter values that may be extracted. Right now either {@link String}
+ * or {@link Inclusion}
+ */
+public interface OneDimensionalQueryParam<P> {
+
+    Set<P> getParams();
+}

--- a/src/main/java/io/katharsis/queryParams/params/QueryParamNameValuePair.java
+++ b/src/main/java/io/katharsis/queryParams/params/QueryParamNameValuePair.java
@@ -1,0 +1,58 @@
+package io.katharsis.queryParams.params;
+
+/**
+ * Represents a pair (parameterName, parameterValue). Allows you to build links containing
+ * parameter data. Note the toString() method.
+ */
+public class QueryParamNameValuePair {
+
+    private final String name;
+
+    private final String value;
+
+    public QueryParamNameValuePair(String name, String value) {
+        if (name == null || value == null)
+            throw new IllegalArgumentException("Name and value must be non-null");
+
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        QueryParamNameValuePair that = (QueryParamNameValuePair) o;
+
+        if (!name.equals(that.name)) return false;
+        return value.equals(that.value);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + value.hashCode();
+        return result;
+    }
+
+    /**
+     * Get a string representation like "filter[projects][name]=projectX"
+     * @return parameterName=value 
+     */
+    @Override
+    public String toString() {
+        return name + "=" + value;
+    }
+
+
+}

--- a/src/main/java/io/katharsis/queryParams/params/QueryParamsHelper.java
+++ b/src/main/java/io/katharsis/queryParams/params/QueryParamsHelper.java
@@ -1,0 +1,374 @@
+package io.katharsis.queryParams.params;
+
+import io.katharsis.queryParams.QueryParams;
+import io.katharsis.queryParams.RestrictedPaginationKeys;
+import io.katharsis.queryParams.RestrictedSortingValues;
+import io.katharsis.queryParams.include.Inclusion;
+import static io.katharsis.resource.RestrictedQueryParamsMembers.fields;
+import static io.katharsis.resource.RestrictedQueryParamsMembers.filter;
+import static io.katharsis.resource.RestrictedQueryParamsMembers.group;
+import static io.katharsis.resource.RestrictedQueryParamsMembers.include;
+import static io.katharsis.resource.RestrictedQueryParamsMembers.page;
+import static io.katharsis.resource.RestrictedQueryParamsMembers.sort;
+
+import java.util.*;
+import java.util.Map.Entry;
+
+/**
+ * Eases the extraction of parameters and allows collecting all passed parameters.
+ * Usage examples:
+ * <pre>
+ * &#47;&#47; get all filter parameter values 
+ * Set&lt;String&gt; projectNames = 
+ * 	QueryParamsHelper
+ * 		.with(queryParams)
+ * 		.filters()
+ * 		.get("projects", "name")
+ * 		.all();
+ * 
+ * &#47;&#47; get one specific sort param value
+ * QueryParamsHelper helper = new QueryParamsHelper(queryParams);
+ * RestrictedSortingValues projectNameSort = helper.sortings().get("project", "name").one();
+ * 
+ * &#47;&#47; collect all filter parameters there are 
+ * Set&lt;QueryParamNameValuePair&gt; all = helper.filters().all();
+ * </pre>
+ */
+public class QueryParamsHelper {
+
+    private QueryParams queryParams;
+
+    public QueryParamsHelper(QueryParams params){
+        if (params == null)
+            throw new IllegalArgumentException("QueryParams must not be null");
+        queryParams = params;
+    }
+
+    public static QueryParamsHelper with(QueryParams queryParams) {
+        return new QueryParamsHelper(queryParams);
+    }
+
+    public TwoDimQueryable<String> filters() {
+        return new TwoDimQueryable<>(queryParams.getFilters(), filter.name());
+    }
+    
+    public OneDimQueryable<String> groupings() {
+    	return new OneDimQueryable<String>(queryParams.getGrouping(), group.name());
+    }
+    
+    public OneDimQueryable<String> fields() {
+    	return new OneDimQueryable<String>(queryParams.getIncludedFields(), fields.name());
+    }
+    
+    public OneDimQueryable<Inclusion> inclusions() {
+    	return new OneDimQueryable<Inclusion>(queryParams.getIncludedRelations(), include.name());
+    }
+    
+    public TwoDimOneValueQueryable<RestrictedSortingValues> sortings() {
+    	return new TwoDimOneValueQueryable<>(queryParams.getSorting(), sort.name());
+    }
+    
+    public PageHelper page() {
+    	return new PageHelper(queryParams.getPagination());
+    }
+    
+    public class PageHelper {
+    	
+    	private Map<RestrictedPaginationKeys, String> nameValueMap;
+    	
+    	private PageHelper(Map<RestrictedPaginationKeys, String> data) {
+    		this.nameValueMap = data;
+    	}
+    	
+    	private Integer lookupValue(RestrictedPaginationKeys key) {
+    		if (nameValueMap == null)
+        		return null;
+        	
+        	String value = nameValueMap.get(key);
+        	if (value == null)
+        		return null;
+        	
+        	return Integer.parseInt(value);
+    	}
+    	
+    	public Integer number() {
+    		return lookupValue(RestrictedPaginationKeys.number);
+    	}
+    	
+    	public Integer size() {
+    		return lookupValue(RestrictedPaginationKeys.size);
+    	}
+    	
+    	public Integer limit() {
+    		return lookupValue(RestrictedPaginationKeys.limit);
+    	}
+    	
+    	public Integer offset() {
+    		return lookupValue(RestrictedPaginationKeys.offset);
+    	}
+    	
+    	public Set<QueryParamNameValuePair> all() {
+    		HashSet<QueryParamNameValuePair> allParams = new HashSet<>();
+    		
+    		for (RestrictedPaginationKeys key : RestrictedPaginationKeys.values()) {
+    			Integer value = lookupValue(key);
+    			if (value == null)
+    				continue;
+    			
+    			String template = "%s[%s]";
+    			String name = String.format(template, page.name(), key.name());
+    			allParams.add(new QueryParamNameValuePair(name, value.toString()));
+    		}
+    		return allParams;
+    	}
+    }
+    
+    /**
+     * Query Helper for parameters that only use a one dimensional array
+     * @param <E> type of the parameter values to retrieve
+     */
+    public class TwoDimOneValueQueryable<E> {
+
+		private Map<String, ? extends TwoDimensionalQueryParamSingleValue<E>> firstDimMap;
+		
+		private String topLevelParamName;
+
+		private TwoDimOneValueQueryable(
+				TypedParams<? extends TwoDimensionalQueryParamSingleValue<E>> param,
+				String topLevelParamName) {
+			
+			if (param != null)
+				this.firstDimMap = param.getParams();
+			
+			this.topLevelParamName = topLevelParamName;
+		}
+		
+		public SetWrapper<E> get(String resourceName, String paramName) {
+			if (firstDimMap == null)
+				return new SetWrapper<>();
+			
+			if (!firstDimMap.containsKey(resourceName))
+				return new SetWrapper<>();
+			
+            TwoDimensionalQueryParamSingleValue<E> secondDimension = firstDimMap.get(resourceName);
+            if (secondDimension == null)
+                return new SetWrapper<>();
+
+            E value = secondDimension.getParams().get(paramName);
+            return new SetWrapper<E>(value);
+		}
+		
+        public Set<QueryParamNameValuePair> all() {
+
+            String paramNameTemplate = topLevelParamName + "[%s][%s]";
+            HashSet<QueryParamNameValuePair> allParams = new LinkedHashSet<>();
+            
+            if (firstDimMap == null)
+            	return allParams;
+
+            // iterate over everything in eg sort[...]
+			for (Entry<String, ? extends TwoDimensionalQueryParamSingleValue<E>> entry : firstDimMap.entrySet()) {
+				String resourceName = entry.getKey();
+
+                TwoDimensionalQueryParamSingleValue<E> secondDim = entry.getValue();
+                if (secondDim == null)
+                	continue;
+             
+                // iterate over everything in eg sort[resourceName][...]
+                for (Entry<String, E> secondDimEntry : secondDim.getParams().entrySet()) {
+                	E value = secondDimEntry.getValue();
+                	if (value == null)
+                		continue;
+                	
+                	String paramName = secondDimEntry.getKey();                	
+                	String name = String.format(paramNameTemplate, resourceName, paramName);
+                    allParams.add(new QueryParamNameValuePair(name, value.toString()));
+                }
+            }
+            return allParams;
+        }    	
+    }
+    
+    /**
+     * Query Helper for parameters that only use a one dimensional array
+     * @param <E> type of the parameter values to retrieve
+     */
+    public class OneDimQueryable<E> {
+
+		private Map<String, ? extends OneDimensionalQueryParam<E>> nameValueMap;
+		
+		private String topLevelParamName;
+
+		private OneDimQueryable(TypedParams<? extends OneDimensionalQueryParam<E>> param, String topLevelParamName) {
+			if (param != null)
+				this.nameValueMap = param.getParams();
+			
+			this.topLevelParamName = topLevelParamName;
+		}
+		
+		/**
+		 * Grouping parameters for the passed resourceName
+		 * @param resourceName of group parameters to consider
+		 */
+		public SetWrapper<E> get(String resourceName) {
+			if (nameValueMap == null)
+				return new SetWrapper<>();
+			
+			if (!nameValueMap.containsKey(resourceName))
+				return new SetWrapper<>();
+			
+			OneDimensionalQueryParam<E> mapValue = nameValueMap.get(resourceName);
+			if (mapValue == null)
+				return new SetWrapper<>();
+			
+			Set<E> values = nameValueMap.get(resourceName).getParams();
+			return new SetWrapper<E>(values);
+		}
+		
+        public Set<QueryParamNameValuePair> all() {
+
+            String paramNameTemplate = topLevelParamName + "[%s]";
+            HashSet<QueryParamNameValuePair> allParams = new LinkedHashSet<>();
+            
+            if (nameValueMap == null)
+            	return allParams;
+
+            // iterate over everything in eg group[...]
+            for (Entry<String, ? extends OneDimensionalQueryParam<E>> entry : nameValueMap.entrySet()) {
+                String resourceName = entry.getKey();
+
+                if (entry.getValue() == null)
+                	continue;
+                
+                // iterate over everything in group[resouceName]=...
+                for (E value : entry.getValue().getParams()) {
+                    String name = String.format(paramNameTemplate, resourceName);
+                    allParams.add(new QueryParamNameValuePair(name, value.toString()));
+                }
+            }
+
+            return allParams;
+        }    	
+    }
+    
+
+    public class TwoDimQueryable<E> {
+
+        private Map<String, ? extends TwoDimensionalQueryParam<E>> firstDimMap;
+
+        private String topLevelParamName;
+
+        private TwoDimQueryable(TypedParams<? extends TwoDimensionalQueryParam<E>> param, String topLevelParamName) {
+        	if (param != null)
+        		this.firstDimMap = param.getParams();
+        	
+            this.topLevelParamName = topLevelParamName;
+        }
+
+        /**
+         * Get access to the set of values identified through:
+         * @param resourceName
+         * @param paramName
+         * @return SetWrapper instance that allows you to get one() or all() parameter values
+         */
+        public SetWrapper<E> get(String resourceName, String paramName) {
+        	if (firstDimMap == null)
+        		return new SetWrapper<>();
+        	
+            if (!firstDimMap.containsKey(resourceName))
+                return new SetWrapper<>();
+
+            TwoDimensionalQueryParam<E> secondDimension = firstDimMap.get(resourceName);
+            if (secondDimension == null)
+                return new SetWrapper<>();
+
+            Set<E> values = secondDimension.getParams().get(paramName);
+            return new SetWrapper<E>(values);
+        }
+
+        /**
+         * @return all query parameters and their values that were collected under e.g. filter[...][...]
+         */
+        public Set<QueryParamNameValuePair> all() {
+
+            String paramNameTemplate = topLevelParamName + "[%s][%s]";
+            HashSet<QueryParamNameValuePair> allParams = new LinkedHashSet<>();
+            
+            if (firstDimMap == null)
+            	return allParams;
+
+            // iterate over everything in filter[...]
+            for (Map.Entry<String, ? extends TwoDimensionalQueryParam<E>> entry : firstDimMap.entrySet()) {
+                String resourceName = entry.getKey();
+
+                TwoDimensionalQueryParam<E> secondDim = entry.getValue();
+                if (secondDim == null)
+                    continue;
+
+                // iterate over everything in filter[resouceName][...]
+                for(Map.Entry<String, Set<E>> secondDimEntry : secondDim.getParams().entrySet()) {
+                    String paramName = secondDimEntry.getKey();
+
+                    if (secondDimEntry.getValue() == null)
+                        continue;
+
+                    // iterate over everything in filter[resouceName][paramName]=...
+                    for (E value : secondDimEntry.getValue()) {
+                        String name = String.format(paramNameTemplate, resourceName, paramName);
+                        allParams.add(new QueryParamNameValuePair(name, value.toString()));
+                    }
+                }
+            }
+            return allParams;
+        }
+
+    }
+
+    public class SetWrapper<T>{
+
+        private Set<T> parameterValues;
+
+        private SetWrapper() {}
+        
+        /**
+         * Constructor for cases where only one value may be associated
+         * with a certain parameter
+         * @param value associated with a certain parameter
+         */
+        private SetWrapper(T value) {
+        	parameterValues = new HashSet<T>();
+        	parameterValues.add(value);
+        }
+
+        /**
+         * Constructor is fine if a null value is passed as argument.
+         * The getter methods are null-safe.
+         * @param values associated with a certain parameter
+         */
+        private SetWrapper(Set<T> values) {
+            parameterValues = values;
+        }
+
+        /**
+         * @return first parameter that is found in the set of passed parameters
+         * or null if none were passed
+         */
+        public T one() {
+            if (parameterValues == null)
+                return null;
+
+            return parameterValues.size() > 0 ? parameterValues.iterator().next() : null;
+        }
+
+        /**
+         * @return either values that were passed or an empty set, but never null
+         */
+        public Set<T> all() {
+            if (parameterValues == null)
+                return new HashSet<>();
+
+            return parameterValues;
+        }
+
+    }
+}

--- a/src/main/java/io/katharsis/queryParams/params/SortingParams.java
+++ b/src/main/java/io/katharsis/queryParams/params/SortingParams.java
@@ -5,14 +5,15 @@ import io.katharsis.queryParams.RestrictedSortingValues;
 import java.util.HashMap;
 import java.util.Map;
 
-public class SortingParams {
+public class SortingParams implements TwoDimensionalQueryParamSingleValue<RestrictedSortingValues> {
     private Map<String, RestrictedSortingValues> params = new HashMap<>();
 
     public SortingParams(Map<String, RestrictedSortingValues> params) {
         this.params = params;
     }
 
-    public Map<String, RestrictedSortingValues> getParams() {
+    @Override
+	public Map<String, RestrictedSortingValues> getParams() {
         return params;
     }
 

--- a/src/main/java/io/katharsis/queryParams/params/TwoDimensionalQueryParam.java
+++ b/src/main/java/io/katharsis/queryParams/params/TwoDimensionalQueryParam.java
@@ -1,0 +1,16 @@
+package io.katharsis.queryParams.params;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Interface for any filter that uses a two-dimensional string-indexed array in the parameter name.<br/>
+ * Eg. filter[...][...]
+ *
+ * @param <P> Type of the parameter values that may be extracted. Right now only {@link String} is used.
+ */
+public interface TwoDimensionalQueryParam<P> {
+
+    Map<String, Set<P>> getParams();
+    
+}

--- a/src/main/java/io/katharsis/queryParams/params/TwoDimensionalQueryParamSingleValue.java
+++ b/src/main/java/io/katharsis/queryParams/params/TwoDimensionalQueryParamSingleValue.java
@@ -1,0 +1,17 @@
+package io.katharsis.queryParams.params;
+
+import java.util.Map;
+import io.katharsis.queryParams.include.Inclusion;
+
+/**
+ * Interface  for any filter that uses a one-dimensional string-indexed array in the parameter name
+ * and cannot return more than just a single value.
+ * Eg. sort[...][...]=(asc|desc)
+ *
+ * @param <P> Type of the parameter values that may be extracted. Right now either {@link String}
+ * or {@link Inclusion}
+ */
+public interface TwoDimensionalQueryParamSingleValue<P> {
+
+	public Map<String, P> getParams();
+}

--- a/src/test/java/io/katharsis/queryParams/QueryParamsHelperTest.java
+++ b/src/test/java/io/katharsis/queryParams/QueryParamsHelperTest.java
@@ -1,0 +1,224 @@
+package io.katharsis.queryParams;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.katharsis.queryParams.include.Inclusion;
+import io.katharsis.queryParams.params.QueryParamNameValuePair;
+import io.katharsis.queryParams.params.QueryParamsHelper;
+
+public class QueryParamsHelperTest {
+	
+    private Map<String, Set<String>> paramDataMap;
+    private QueryParamsParser parser = new DefaultQueryParamsParser();
+
+    @Before
+    public void prepare() {
+        paramDataMap = new HashMap<>();
+    }
+	
+    @Test
+    public void testNullPointerSafeness() {
+    	QueryParams params = new QueryParams();
+        QueryParamsHelper qpHelper = new QueryParamsHelper(params);
+        
+        assertEquals(0, qpHelper.filters().all().size());
+        assertEquals(0, qpHelper.filters().get("doesnt", "matter").all().size());
+        assertNull(qpHelper.filters().get("doesnt", "matter").one());
+        
+        assertEquals(0, qpHelper.sortings().all().size());
+        assertEquals(0, qpHelper.sortings().get("doesnt", "matter").all().size());
+        assertNull(qpHelper.sortings().get("doesnt", "matter").one());
+        
+        assertEquals(0, qpHelper.groupings().all().size());
+        assertEquals(0, qpHelper.groupings().get("igual").all().size());
+        assertNull(qpHelper.groupings().get("igual").one());
+        
+        assertEquals(0, qpHelper.inclusions().all().size());
+        assertEquals(0, qpHelper.inclusions().get("igual").all().size());
+        assertNull(qpHelper.inclusions().get("igual").one());
+        
+        assertEquals(0, qpHelper.fields().all().size());
+        assertEquals(0, qpHelper.fields().get("igual").all().size());
+        assertNull(qpHelper.fields().get("igual").one());
+        
+        assertNull(qpHelper.page().size());
+        assertNull(qpHelper.page().limit());
+        assertNull(qpHelper.page().number());
+        assertNull(qpHelper.page().offset());
+    }
+    
+	@Test
+	public void testQueryParamsHelperFilters() {
+        paramDataMap.put("filter[users][name]", Collections.singleton("John"));
+        paramDataMap.put("random[users][name]", Collections.singleton("John"));
+
+        QueryParams params = new QueryParams();
+        QueryParamsHelper qpHelper = new QueryParamsHelper(params);
+        
+        params.setFilters(parser.parseFiltersParameters(paramDataMap));
+        assertEquals(1, qpHelper.filters().all().size());      
+        
+        paramDataMap.put("filter[users][name]", new HashSet<String>(Arrays.asList(new String[]{"John", "John John"})));
+        params.setFilters(parser.parseFiltersParameters(paramDataMap));
+        Set<QueryParamNameValuePair> filters = qpHelper.filters().all();
+        assertEquals(2, filters.size());
+        
+        assertTrue(filters.contains(new QueryParamNameValuePair("filter[users][name]", "John")));
+        assertTrue(filters.contains(new QueryParamNameValuePair("filter[users][name]", "John John")));
+        
+        Set<String> values = qpHelper.filters().get("users", "name").all();
+        assertEquals(2, values.size());
+        assertTrue(values.contains("John"));
+        assertTrue(values.contains("John John"));
+        
+        String value = QueryParamsHelper.with(params).filters().get("users", "name").one();
+        assertEquals(value, "John");
+	}
+	
+	@Test
+	public void testQueryParamsHelperGrouping()
+	{
+        paramDataMap.put("group[users]", Collections.singleton("name"));
+
+        QueryParams params = new QueryParams();
+        QueryParamsHelper qpHelper = new QueryParamsHelper(params);
+        
+        params.setGrouping(parser.parseGroupingParameters(paramDataMap));
+        assertEquals(1, qpHelper.groupings().all().size());      
+        
+        paramDataMap.put("group[users]", new HashSet<String>(Arrays.asList(new String[]{"name", "age"})));
+        params.setGrouping(parser.parseGroupingParameters(paramDataMap));
+        Set<QueryParamNameValuePair> groupings = qpHelper.groupings().all();
+        assertEquals(2, groupings.size());
+        
+        assertTrue(groupings.contains(new QueryParamNameValuePair("group[users]", "name")));
+        assertTrue(groupings.contains(new QueryParamNameValuePair("group[users]", "age")));
+        
+        Set<String> values = qpHelper.groupings().get("users").all();
+        assertEquals(2, values.size());
+        assertTrue(values.contains("name"));
+        assertTrue(values.contains("age"));
+        
+        String value = QueryParamsHelper.with(params).groupings().get("users").one();
+        assertEquals(value, "name");
+	}
+	
+	@Test
+	public void testQueryParamsHelperFields()
+	{
+        paramDataMap.put("fields[users]", Collections.singleton("name"));
+
+        QueryParams params = new QueryParams();
+        QueryParamsHelper qpHelper = new QueryParamsHelper(params);
+        
+        params.setIncludedFields(parser.parseIncludedFieldsParameters(paramDataMap));
+        assertEquals(1, qpHelper.fields().all().size());      
+        
+        paramDataMap.put("fields[users]", new HashSet<String>(Arrays.asList(new String[]{"name", "age"})));
+        params.setIncludedFields(parser.parseIncludedFieldsParameters(paramDataMap));
+        Set<QueryParamNameValuePair> fields = qpHelper.fields().all();
+        assertEquals(2, fields.size());
+        
+        assertTrue(fields.contains(new QueryParamNameValuePair("fields[users]", "name")));
+        assertTrue(fields.contains(new QueryParamNameValuePair("fields[users]", "age")));
+        
+        Set<String> values = qpHelper.fields().get("users").all();
+        assertEquals(2, values.size());
+        assertTrue(values.contains("name"));
+        assertTrue(values.contains("age"));
+        
+        String value = QueryParamsHelper.with(params).fields().get("users").one();
+        assertEquals(value, "name");
+	}
+	
+	@Test
+	public void testQueryParamsHelperInclusions()
+	{
+        paramDataMap.put("include[projects]", Collections.singleton("tasks"));
+
+        QueryParams params = new QueryParams();
+        QueryParamsHelper qpHelper = new QueryParamsHelper(params);
+        
+        params.setIncludedRelations(parser.parseIncludedRelationsParameters(paramDataMap));
+        assertEquals(1, qpHelper.inclusions().all().size());
+        
+        paramDataMap.put("include[projects]", new HashSet<String>(Arrays.asList(new String[]{"tasks", "owner"})));
+        params.setIncludedRelations(parser.parseIncludedRelationsParameters(paramDataMap));
+        Set<QueryParamNameValuePair> fields = qpHelper.inclusions().all();
+        assertEquals(2, fields.size());
+        
+        assertTrue(fields.contains(new QueryParamNameValuePair("include[projects]", "tasks")));
+        assertTrue(fields.contains(new QueryParamNameValuePair("include[projects]", "owner")));
+        
+        Set<Inclusion> values = qpHelper.inclusions().get("projects").all();
+        assertEquals(2, values.size());
+        assertTrue(values.contains(new Inclusion("tasks")));
+        assertTrue(values.contains(new Inclusion("owner")));
+        
+        Inclusion value = QueryParamsHelper.with(params).inclusions().get("projects").one();
+        
+        // set gives no guarantee about order of elements, so in this case we end up
+        // getting the owner, not the tasks value
+        assertEquals(value, new Inclusion("owner"));
+	}
+	
+	@Test
+	public void testQueryParamsHelperSorting()
+	{
+        paramDataMap.put("sort[projects][name]", Collections.singleton("asc"));
+
+        QueryParams params = new QueryParams();
+        QueryParamsHelper qpHelper = new QueryParamsHelper(params);
+        
+        params.setSorting(parser.parseSortingParameters(paramDataMap));
+        assertEquals(1, qpHelper.sortings().all().size());      
+        
+        // we may only get one value for sorting, even if we received two values
+        paramDataMap.put("sort[projects][name]", new HashSet<String>(Arrays.asList(new String[]{"asc", "desc"})));
+        params.setSorting(parser.parseSortingParameters(paramDataMap));
+        Set<QueryParamNameValuePair> sortings = qpHelper.sortings().all();
+        assertEquals(1, sortings.size()); // note it says 1!
+        
+        assertTrue(sortings.contains(new QueryParamNameValuePair("sort[projects][name]", "asc")));
+        
+        Set<RestrictedSortingValues> values = qpHelper.sortings().get("projects", "name").all();
+        assertEquals(1, values.size());
+        assertTrue(values.contains(RestrictedSortingValues.asc));
+        
+        RestrictedSortingValues value = QueryParamsHelper.with(params).sortings().get("projects", "name").one();
+        assertEquals(value, RestrictedSortingValues.asc);
+	}
+	
+	@Test
+	public void testQueryParamsHelperPagination()
+	{
+        paramDataMap.put("page[size]", Collections.singleton("12"));
+        paramDataMap.put("page[number]", Collections.singleton("11"));
+        paramDataMap.put("page[offset]", Collections.singleton("3"));
+        paramDataMap.put("page[limit]", Collections.singleton("8"));
+
+        QueryParams params = new QueryParams();
+        params.setPagination(parser.parsePaginationParameters(paramDataMap));
+        QueryParamsHelper qpHelper = new QueryParamsHelper(params);
+        
+        assertEquals(12, (int) qpHelper.page().size());
+        assertEquals(11, (int) qpHelper.page().number());
+        assertEquals(3, (int) qpHelper.page().offset());
+        assertEquals(8, (int) qpHelper.page().limit());
+        
+        assertEquals(4, qpHelper.page().all().size());
+	}
+	
+}


### PR DESCRIPTION
The QueryParamsHelper allows for easier retrieval of certain parameter
values as well as collecting all the parameters that were passed in the
request.